### PR TITLE
Fix use of substitute in line of augment.R

### DIFF
--- a/R/augment.R
+++ b/R/augment.R
@@ -622,7 +622,7 @@ augment = function( data, data_key, n_events, pattern,
     final[ status == state[[ 3 ]], substitute( t_augmented ) := get( t_death ) ]
   }
   if ( inherits( eval( substitute( data$t_start ) ), 'Date' ) ) {
-    final[ , paste( substitute( t_augmented ), '_int', sep = '' ) := as.integer( get( t_augmented ) ) ]
+    final[ , paste0( t_augmented, '_int' ) := as.integer( get( t_augmented ) ) ]
     id_col = which( names( data ) == substitute( t_start ) )
     setcolorder( final, c( 1:( id_col - 1 ), ( dim( final )[ 2 ] - 1 ), dim( final )[ 2 ],
                            id_col:( dim( final )[ 2 ] - 2 ) ) )


### PR DESCRIPTION
Hi @contefranz, 

After installing data.table from github master,

data.table::update_dev_pkg()

And then running R CMD check on msmtools, I get the following new failure, (which is not present if you use data.table from CRAN)

> --- re-building 'msmtools.Rmd' using rmarkdown_notangle
Quitting from lines 300-318 [multistate_model] (msmtools.Rmd)
Error: processing vignette 'msmtools.Rmd' failed with diagnostics:
object 'augmented_int' not found
--- failed re-building 'msmtools.Rmd'

Before uploading new versions to CRAN, data.table needs to ensure that updates do not break CRAN checks in dependent packages like msmtools (see also https://github.com/Rdatatable/data.table/issues/6033). So can you please submit an updated version of msmtools to CRAN, that fixes this check issue? In particular, I would suggest to avoid using `substitute()` on the LHS of your `:=` calls, and instead use the column variable directly. For example,

``` r
final[ status == state[[ 3 ]], substitute( t_augmented ) := get( t_death ) ]
```

would become

``` r
final[ status == state[[ 3 ]], ( t_augmented ) := get( t_death ) ]
```
In future versions of data.table, we will start to deprecate the use of additional checks for `substitute(col)` on the LHS of assignment calls so many of these calls would no longer work as previous versions allowed. 