### PR TITLE
Prepare msmtools 2.0.3 CRAN resubmission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ inst/doc
 *.dll
 vignettes/msmtools.R
 vignettes/msmtools.html
+/*.tar.gz

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: msmtools
 Type: Package
 Title: Building Augmented Data to Run Multi-State Models with 'msm' Package
-Version: 2.0.2
-Date: 2026-04-20
+Version: 2.0.3
+Date: 2026-05-24
 Authors@R: person("Francesco", "Grossetti",
     email = "francesco.grossetti@unibocconi.it",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0002-5130-7745"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# msmtools 2.0.3
+***
+
+This is a CRAN resubmission after **msmtools** was archived because compatibility
+issues with newer **data.table** releases were not corrected in time. No
+user-facing behaviour has changed.
+
+### Bug fixes
+
+* Kept the compatibility fixes for current **data.table** releases by avoiding
+  deprecated `substitute()` calls on the left-hand side of `:=` assignments.
+
+* Retained the focused non-standard evaluation cleanup in `augment()` and
+  `polish()` needed for CRAN checks, without introducing the broader refactor
+  attempted on the historical `substitute_fix` branch.
+
+### Documentation
+
+* Updated release metadata for the CRAN resubmission.
+
 # msmtools 2.0.2
 ***
 

--- a/R/augment.R
+++ b/R/augment.R
@@ -620,7 +620,7 @@ augment = function( data, data_key, n_events, pattern,
     final[ status == state[[ 3 ]], ( t_augmented ) := get( t_death ) ]
   }
   if ( inherits( data[[ t_start ]], 'Date' ) ) {
-    final[ , paste0( t_augmented, '_int' ) := as.integer( get( t_augmented ) ) ]
+    final[ , ( paste0( t_augmented, '_int' ) ) := as.integer( get( t_augmented ) ) ]
     id_col = which( names( data ) == t_start )
     setcolorder( final, c( 1:( id_col - 1 ), ( dim( final )[ 2 ] - 1 ), dim( final )[ 2 ],
                            id_col:( dim( final )[ 2 ] - 2 ) ) )
@@ -631,7 +631,7 @@ augment = function( data, data_key, n_events, pattern,
       cat( '---\n' )
     }
   } else if ( inherits( data[[ t_start ]], 'difftime' ) ) {
-    final[ , paste0( t_augmented, '_num' ) := as.numeric( get( t_augmented ) ) ]
+    final[ , ( paste0( t_augmented, '_num' ) ) := as.numeric( get( t_augmented ) ) ]
     id_col = which( names( data ) == t_start )
     setcolorder( final, c( 1:( id_col - 1 ), ( dim( final )[ 2 ] - 1 ), dim( final )[ 2 ],
                            id_col:( dim( final )[ 2 ] - 2 ) ) )
@@ -729,4 +729,3 @@ augment = function( data, data_key, n_events, pattern,
   final[]
   return( final )
 }
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Building augmented data for multi-state models: the `msmtools` package
 
 [![lifecycle](https://lifecycle.r-lib.org/articles/figures/lifecycle-maturing.svg)](https://lifecycle.r-lib.org/articles/stages.html)
-[![release](https://img.shields.io/badge/dev.%20version-2.0.2-blue)](https://github.com/contefranz/msmtools)
+[![release](https://img.shields.io/badge/dev.%20version-2.0.3-blue)](https://github.com/contefranz/msmtools)
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/msmtools)](https://cran.r-project.org/package=msmtools)
 
 ***

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,38 @@
+# msmtools 2.0.3
+
+### Release summary
+
+This is a CRAN resubmission after msmtools was archived on 2024-09-27 because
+compatibility issues were not corrected despite reminders. The release addresses
+deprecated data.table assignment patterns and does not introduce user-facing
+behaviour changes.
+
+### Package development
+
+* macOS Tahoe 26.5 with R 4.5.1
+
+### R CMD build
+
+* local macOS build with R CMD build
+* vignette build completed with pandoc discovered through Quarto
+* win-builder submission for R-release completed on 2026-05-24; results are
+  pending by e-mail
+* rhub submission was not completed locally because no GitHub personal access
+  token was available to `rhub::rhub_check()`
+
+### R CMD check results
+
+* Local `R CMD check --no-manual --as-cran` completed with no ERRORs and no
+  WARNINGs.
+* Local check reported NOTEs caused by the restricted local environment:
+  unavailable CRAN/Bioconductor/GitHub/ORCID URL checks, inability to verify the
+  current time, and pandoc not being visible inside one subprocess for top-level
+  README/NEWS checks.
+* Re-run checks in a networked CRAN-like environment before submission and
+  replace this section with the final results.
+
+***
+
 # msmtools 2.0.1
 
 ### Release summary
@@ -130,4 +165,3 @@ There was 1 NOTE:
 Maintainer: 'Francesco Grossetti <francesco.grossetti@polimi.it>'
 
 New submission
-


### PR DESCRIPTION
## Summary
- Bump package metadata to `2.0.3` and refresh the release date.
- Add a new `NEWS.md` entry and update `cran-comments.md` for the CRAN resubmission.
- Update the README release badge and ignore generated source tarballs in `.gitignore`.
- Make the remaining `data.table` column-name assignments in `augment()` use the parenthesized LHS style for consistency.

## Testing
- `devtools::test()` passed.
- `R CMD build` and `R CMD check --no-manual --as-cran` passed locally with only environment-related NOTEs.
- Win-builder submission was completed for the release tarball.