### PR TITLE
Prepare v2.0.4 dependency baseline

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: msmtools
 Type: Package
 Title: Building Augmented Data to Run Multi-State Models with 'msm' Package
-Version: 2.0.3
+Version: 2.0.4
 Date: 2026-05-24
 Authors@R: person("Francesco", "Grossetti",
     email = "francesco.grossetti@unibocconi.it",
@@ -13,18 +13,19 @@ URL: https://github.com/contefranz/msmtools
 BugReports: https://github.com/contefranz/msmtools/issues
 License: GPL-3
 LazyData: TRUE
-RoxygenNote: 7.3.3
-Depends: R (>= 3.0)
-Imports: data.table (>= 1.9.6),
-    msm (>= 1.6),
-    survival (>= 2.38.0),
-    ggplot2 (>= 3.3.3),
-    patchwork (>= 1.1.1),
-    scales (>= 1.1.1)
-Suggests: testthat,
-    knitr,
-    rmarkdown,
-    roxygen2,
-    usethis
+Roxygen: list(markdown = TRUE)
+Config/roxygen2/version: 8.0.0
+Depends: R (>= 4.1)
+Imports: data.table (>= 1.18.4),
+    msm (>= 1.8.2),
+    survival (>= 3.8-6),
+    ggplot2 (>= 4.0.3),
+    patchwork (>= 1.3.2),
+    scales (>= 1.4.0)
+Suggests: testthat (>= 3.3.2),
+    knitr (>= 1.51),
+    rmarkdown (>= 2.31),
+    roxygen2 (>= 8.0.0)
+Config/testthat/edition: 3
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,24 @@
+# msmtools 2.0.4
+***
+
+### CHANGES
+
+* Raised the supported baseline to R 4.1 and current CRAN releases of the main
+  runtime dependencies used by **msmtools**.
+
+* Removed the unused development helper **usethis** from `Suggests`.
+
+### DOCUMENTATION
+
+* Migrated package documentation metadata to **roxygen2** 8.0.0 with markdown
+  documentation enabled.
+
+### TESTS
+
+* Replaced deprecated `testthat::expect_is()` calls with
+  `testthat::expect_s3_class()` for compatibility with **testthat** 3rd
+  edition.
+
 # msmtools 2.0.3
 ***
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Building augmented data for multi-state models: the `msmtools` package
 
 [![lifecycle](https://lifecycle.r-lib.org/articles/figures/lifecycle-maturing.svg)](https://lifecycle.r-lib.org/articles/stages.html)
-[![release](https://img.shields.io/badge/dev.%20version-2.0.3-blue)](https://github.com/contefranz/msmtools)
+[![release](https://img.shields.io/badge/dev.%20version-2.0.4-blue)](https://github.com/contefranz/msmtools)
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/msmtools)](https://cran.r-project.org/package=msmtools)
 
 ***

--- a/man/hosp.Rd
+++ b/man/hosp.Rd
@@ -7,28 +7,28 @@
 \format{
 A \code{data.table} with 53 rows and 12 variables:
 \describe{
-  \item{subj}{Subject ID (integer)}
-  \item{adm_number}{Hospital admissions counter (integer)}
-  \item{gender}{Gender of patient (factor with 2 levels: "F" = females, "M" = males)}
-  \item{age}{Age of patient in years at the given observation (integer)}
-  \item{rehab}{Rehabilitation flag: if the admission has been in rehabilitation,
-  then rehab = 1, else = 0 (integer)}
-  \item{it}{Intensive Therapy flag: if the admission has been in intensive therapy,
-  then it = 1, else = 0 (integer)}
-  \item{rehab_it}{String which in one place marks the hospital admission types based on
-  rehab and it. The standard admission is coded as "df" (default). If admission was in
-  rehabilitation or in intensive therapy, rehab_it = "rehab" or "it", respectively (character)}
-  \item{label_2}{Subject status at the end of the study. It takes 2 values: "alive" and "dead"
-  (character)}
-  \item{label_3}{Subject status at the end of the study. It takes 3 values: "alive" and "dead_in"
-  and "dead_out" (character)}
-  \item{dateIN}{Exact admission date (date)}
-  \item{dateOUT}{Exact discharge date (date)}
-  \item{dateCENS}{Either censoring time or exact death time (date)}
+\item{subj}{Subject ID (integer)}
+\item{adm_number}{Hospital admissions counter (integer)}
+\item{gender}{Gender of patient (factor with 2 levels: "F" = females, "M" = males)}
+\item{age}{Age of patient in years at the given observation (integer)}
+\item{rehab}{Rehabilitation flag: if the admission has been in rehabilitation,
+then rehab = 1, else = 0 (integer)}
+\item{it}{Intensive Therapy flag: if the admission has been in intensive therapy,
+then it = 1, else = 0 (integer)}
+\item{rehab_it}{String which in one place marks the hospital admission types based on
+rehab and it. The standard admission is coded as "df" (default). If admission was in
+rehabilitation or in intensive therapy, rehab_it = "rehab" or "it", respectively (character)}
+\item{label_2}{Subject status at the end of the study. It takes 2 values: "alive" and "dead"
+(character)}
+\item{label_3}{Subject status at the end of the study. It takes 3 values: "alive" and "dead_in"
+and "dead_out" (character)}
+\item{dateIN}{Exact admission date (date)}
+\item{dateOUT}{Exact discharge date (date)}
+\item{dateCENS}{Either censoring time or exact death time (date)}
 }
 }
 \usage{
-hosp
+data(hosp)
 }
 \description{
 A dataset containing synthetic hospital admissions in the classic longitudinal format.

--- a/man/msmtools-package.Rd
+++ b/man/msmtools-package.Rd
@@ -26,5 +26,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Francesco Grossetti \email{francesco.grossetti@unibocconi.it} (\href{https://orcid.org/0000-0002-5130-7745}{ORCID})
 
+Authors:
+\itemize{
+  \item Francesco Grossetti \email{francesco.grossetti@unibocconi.it} (\href{https://orcid.org/0000-0002-5130-7745}{ORCID})
+}
+
 }
 \keyword{internal}

--- a/tests/testthat/test_dataset_return.R
+++ b/tests/testthat/test_dataset_return.R
@@ -45,11 +45,10 @@ aug.df = augment( hosp, subj, adm_number, label_3,
                   verbose = F, convert = F )
 
 test_that( "returning a data.table when convert = FALSE",
-           expect_is( aug.dt, "data.table" ) )
+           expect_s3_class( aug.dt, "data.table" ) )
 test_that( "returning a data.frame when convert = TRUE",
-           expect_is( aug.df, "data.frame" ) )
+           expect_s3_class( aug.df, "data.frame" ) )
 
 test_that( "objects are identical",
            expect_identical( aug.df, aug.dt ) )
-
 


### PR DESCRIPTION
## Summary

- raises the msmtools baseline to R 4.1 and current CRAN versions of the main runtime dependencies
- migrates roxygen metadata to roxygen2 8.0.0 with markdown documentation enabled
- removes unused usethis from Suggests and updates testthat expectations for edition 3 compatibility

## Validation

- `Rscript -e 'devtools::test()'`
- `RSTUDIO_PANDOC=/Applications/quarto/bin/tools/aarch64 R CMD build .`
- `RSTUDIO_PANDOC=/Applications/quarto/bin/tools/aarch64 R CMD check --no-manual --as-cran msmtools_2.0.4.tar.gz`

The local CRAN-style check completed with 0 ERRORs and 0 WARNINGs. It reported the same 3 local-environment NOTEs as before: restricted URL/ORCID resolution, inability to verify current time, and pandoc not being visible inside one check subprocess for top-level README/NEWS checks.