### PR TITLE
Dev/v2.1.0 core API enhancement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: msmtools
 Type: Package
 Title: Building Augmented Data to Run Multi-State Models with 'msm' Package
-Version: 2.0.10
+Version: 2.1.0
 Date: 2026-05-25
 Authors@R: person("Francesco", "Grossetti",
     email = "francesco.grossetti@unibocconi.it",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,30 @@
+# msmtools 2.1.0
+***
+
+### CHANGES
+
+* Added a `copy` argument to `augment()` and `polish()`. The default
+  `copy = FALSE` preserves the historical memory-efficient by-reference
+  behavior, while `copy = TRUE` protects caller-owned data before preprocessing.
+
+* Clarified the preprocessing contract around **data.table** by-reference
+  semantics. `augment()` may add `n_events` and change the input key when
+  `copy = FALSE`; `polish()` may change the input key while identifying
+  duplicate transitions.
+
+* Added shared validation for scalar logical flags used by preprocessing
+  functions.
+
+### DOCUMENTATION
+
+* Documented the performance and safety tradeoff behind `copy = FALSE` and
+  `copy = TRUE` in the function help, README, and vignette.
+
+### TESTS
+
+* Added tests covering by-reference preservation with `copy = FALSE`, input
+  protection with `copy = TRUE`, and validation of logical flags.
+
 # msmtools 2.0.10
 ***
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,15 +15,28 @@
 * Added shared validation for scalar logical flags used by preprocessing
   functions.
 
+* Made the `augment()` state vocabulary stricter and clearer: custom `state`
+  values must now be supplied as a character vector of three unique labels, not
+  as a list.
+
+* Made `more_status = NULL` explicit in `augment()` so the optional expanded
+  status path is visible in the function signature.
+
 ### DOCUMENTATION
 
 * Documented the performance and safety tradeoff behind `copy = FALSE` and
   `copy = TRUE` in the function help, README, and vignette.
 
+* Clarified that `pattern` describes the terminal outcome schema, while `state`
+  describes the generated transition-state labels.
+
 ### TESTS
 
 * Added tests covering by-reference preservation with `copy = FALSE`, input
   protection with `copy = TRUE`, and validation of logical flags.
+
+* Added tests for custom state vectors, invalid state specifications, and
+  explicit `more_status = NULL`.
 
 # msmtools 2.0.10
 ***

--- a/R/augment-helpers.R
+++ b/R/augment-helpers.R
@@ -13,8 +13,9 @@
   if ( missing_pattern ) {
     stop( "a pattern must be provided" )
   }
-  if ( !inherits( state, "list" ) || length( state ) != 3 ) {
-    stop( "state pattern must be a list of 3 elements" )
+  if ( !is.character( state ) || length( state ) != 3 ||
+       anyNA( state ) || any( !nzchar( state ) ) || anyDuplicated( state ) ) {
+    stop( "state must be a character vector of 3 unique non-missing non-empty labels" )
   }
   if ( missing_t_start || missing_t_end ) {
     stop( "a starting and an ending event times must be provided" )

--- a/R/augment.R
+++ b/R/augment.R
@@ -20,14 +20,14 @@ if ( getRversion() >= "2.15.1" ) {
 #' monotonically increasing within each `data_key` and stops if the check fails
 #' (see Details). If missing, `augment()` creates a variable named `"n_events"`.
 #' @param pattern Either an integer, a factor, or a character variable with 2 or
-#' 3 unique values that gives each subject's status at the end of the study.
-#' `pattern` has a predefined structure. When 2 values are detected, they must
-#' be in the format: 0 = "alive", 1 = "dead". When 3 values are detected, they
-#' must be: 0 = "alive", 1 = "dead during a transition", 2 = "dead after a
-#' transition has ended" (see Details).
-#' @param state A list of exactly three possible states that a subject can
-#' reach. `state` has a predefined structure: `IN`, `OUT`, `DEAD`
+#' 3 unique values that gives each subject's terminal outcome schema. When 2
+#' values are detected, they must be in the format: 0 = "alive", 1 = "dead".
+#' When 3 values are detected, they must be: 0 = "alive",
+#' 1 = "dead during a transition", 2 = "dead after a transition has ended"
 #' (see Details).
+#' @param state A character vector of exactly three unique, non-missing,
+#' non-empty labels used as the generated transition-state vocabulary.
+#' Defaults to `c("IN", "OUT", "DEAD")` (see Details).
 #' @param t_start The starting time of an observation. It can be passed as date,
 #' integer, or numeric format.
 #' @param t_end The ending time of an observation. It can be passed as date,
@@ -47,7 +47,7 @@ if ( getRversion() >= "2.15.1" ) {
 #' `t_start`.
 #' @param more_status A variable that marks further transitions beyond the
 #' default ones given by `state`. `more_status` can be a factor or character
-#' (see Details). If missing, `augment()` ignores it.
+#' (see Details). If `NULL` (default), `augment()` ignores it.
 #' @param check_NA If `TRUE`, `data_key`, `n_events`, `pattern`, `t_start`, and
 #' `t_end` are checked for missing values. If any missing values are found, the
 #' function stops with an error. Default is `FALSE` because `augment()` is not
@@ -70,17 +70,20 @@ if ( getRversion() >= "2.15.1" ) {
 #' first computes a progression number named *n_events* and then runs the same
 #' check.
 #'
-#' Argument `pattern` must follow the expected ordering. With two statuses,
-#' values must correspond to `0 = "alive"` and `1 = "dead"`. With three
-#' statuses, integer values must correspond to `0 = "alive"`,
-#' `1 = "dead inside a transition"`, and
+#' Argument `pattern` describes the terminal outcome schema and must follow the
+#' expected ordering. With two statuses, values must correspond to
+#' `0 = "alive"` and `1 = "dead"`. With three statuses, integer values must
+#' correspond to `0 = "alive"`, `1 = "dead inside a transition"`, and
 #' `2 = "dead outside a transition"`. Character and factor values must follow
 #' the same order. For example, `0` cannot be used to indicate death.
 #'
-#' The order of `state` also matters. The first element is the state at
-#' `t_start` (for example, `"IN"`), the second element is the state at `t_end`
-#' (for example, `"OUT"`), and the third element is the absorbing state (for
-#' example, `"DEAD"`).
+#' Argument `state` describes the generated transition-state vocabulary. Its
+#' order also matters. The first element is the state at `t_start` (for example,
+#' `"IN"`), the second element is the state at `t_end` (for example, `"OUT"`),
+#' and the third element is the absorbing state (for example, `"DEAD"`). A
+#' two-value `pattern` still requires three `state` labels because `augment()`
+#' infers whether death maps to the absorbing state inside or outside the
+#' transition window.
 #'
 #' `more_status` lets `augment()` represent transitions beyond the defaults in
 #' `state`. Standard admissions that add no extra information should use `"df"`
@@ -158,9 +161,9 @@ if ( getRversion() >= "2.15.1" ) {
 #' @export
 
 augment = function( data, data_key, n_events, pattern,
-                    state = list ( "IN", "OUT", "DEAD" ),
+                    state = c( "IN", "OUT", "DEAD" ),
                     t_start, t_end, t_cens, t_death, t_augmented,
-                    more_status, check_NA = FALSE, copy = FALSE,
+                    more_status = NULL, check_NA = FALSE, copy = FALSE,
                     verbosity = getOption( "msmtools.verbosity", "quiet" ) ) {
 
   tic = proc.time()
@@ -199,10 +202,11 @@ augment = function( data, data_key, n_events, pattern,
   } else {
     as.character( substitute( t_augmented ) )
   }
-  more_status = if ( missing( more_status ) ) {
+  more_status_arg = substitute( more_status )
+  more_status = if ( missing( more_status ) || is.null( more_status_arg ) ) {
     NULL
   } else {
-    as.character( substitute( more_status ) )
+    as.character( more_status_arg )
   }
 
   if ( is.null( t_death ) ) {

--- a/R/augment.R
+++ b/R/augment.R
@@ -54,6 +54,10 @@ if ( getRversion() >= "2.15.1" ) {
 #' intended for general consistency checks and the scan can add memory overhead
 #' on very large datasets. `more_status` is always checked for missing values
 #' when supplied.
+#' @param copy If `FALSE` (default), `augment()` keeps the historical
+#' memory-efficient behavior and may modify caller-owned `data` by reference.
+#' If `TRUE`, `data` is copied before any `data.table` operation so the input
+#' object remains unchanged.
 #' @param verbosity Controls informational output. Use `"quiet"` to suppress
 #' status messages, `"summary"` for high-level phase messages and timing, and
 #' `"progress"` for phase messages plus progress bars in long status-building
@@ -82,6 +86,12 @@ if ( getRversion() >= "2.15.1" ) {
 #' `state`. Standard admissions that add no extra information should use `"df"`
 #' for "default" (see Examples, or run `?hosp` and inspect `rehab_it`). More
 #' complex transitions should use concise, self-explanatory labels.
+#'
+#' By default, `augment()` follows **data.table** by-reference semantics to avoid
+#' unnecessary copies of large longitudinal datasets. This means the input may
+#' have its key changed, and `n_events` may be added when the argument is
+#' omitted. Set `copy = TRUE` when the original input object must remain
+#' unchanged.
 #'
 #' The function always returns a `data.table`. Use [as.data.frame()] on the
 #' result if a plain `data.frame` is needed by downstream code.
@@ -150,11 +160,13 @@ if ( getRversion() >= "2.15.1" ) {
 augment = function( data, data_key, n_events, pattern,
                     state = list ( "IN", "OUT", "DEAD" ),
                     t_start, t_end, t_cens, t_death, t_augmented,
-                    more_status, check_NA = FALSE,
+                    more_status, check_NA = FALSE, copy = FALSE,
                     verbosity = getOption( "msmtools.verbosity", "quiet" ) ) {
 
   tic = proc.time()
   verbosity = .msmtools_verbosity( verbosity )
+  .msmtools_validate_flag( copy, "copy" )
+  .msmtools_validate_flag( check_NA, "check_NA" )
   .msmtools_cli_rule( verbosity, "setting everything up" )
 
   .augment_validate_inputs(
@@ -168,6 +180,9 @@ augment = function( data, data_key, n_events, pattern,
     missing_t_cens = missing( t_cens )
   )
 
+  if ( copy ) {
+    data = data.table::copy( data )
+  }
   if ( inherits( data, "data.frame" ) ) {
     setDT( data )
   }

--- a/R/augment.R
+++ b/R/augment.R
@@ -142,7 +142,7 @@ if ( getRversion() >= "2.15.1" ) {
 #' @references Grossetti, F., Ieva, F., and Paganoni, A.M. (2018).
 #' A multi-state approach to patients affected by chronic heart failure.
 #' *Health Care Management Science*, 21, 281-291.
-#' <https://doi.org/10.1007/s10729-017-9400-z>.
+#' \doi{10.1007/s10729-017-9400-z}.
 #'
 #' Jackson, C.H. (2011). Multi-State Models for Panel Data: The
 #' **msm** Package for R. Journal of Statistical Software, 38(8), 1-29.

--- a/R/polish.R
+++ b/R/polish.R
@@ -12,11 +12,20 @@ if ( getRversion() >= "2.15.1" ) {
 #' @param check_NA If `TRUE`, `data_key`, `pattern`, and `time` are checked for
 #' missing values. If any missing values are found, the function stops with an
 #' error. Default is `FALSE`.
+#' @param copy If `FALSE` (default), `polish()` keeps the historical
+#' memory-efficient behavior and may modify caller-owned `data` by reference.
+#' If `TRUE`, `data` is copied before any `data.table` operation so the input
+#' object remains unchanged.
 #'
 #' @details The function searches for cases where two subsequent events for the
 #' same subject land on different states but occur at the same time. When this
 #' happens, the whole subject, as identified by `data_key`, is removed from the
 #' data. The function reports how many subjects were removed.
+#'
+#' By default, `polish()` follows **data.table** by-reference semantics to avoid
+#' unnecessary copies of large augmented datasets. This means the input may have
+#' its key changed while duplicate subjects are identified. Set `copy = TRUE`
+#' when the original input object must remain unchanged.
 #'
 #' The function always returns a `data.table`. Use [as.data.frame()] on the
 #' result if a plain `data.frame` is needed by downstream code.
@@ -40,12 +49,14 @@ if ( getRversion() >= "2.15.1" ) {
 #' @importFrom data.table setDT setkey setkeyv rbindlist uniqueN
 #' @export
 
-polish = function( data, data_key, pattern, time,
-                   check_NA = FALSE,
+polish = function( data, data_key, pattern, time, check_NA = FALSE,
+                   copy = FALSE,
                    verbosity = getOption( "msmtools.verbosity", "quiet" ) ) {
 
   tic = proc.time()
   verbosity = .msmtools_verbosity( verbosity )
+  .msmtools_validate_flag( copy, "copy" )
+  .msmtools_validate_flag( check_NA, "check_NA" )
 
   if ( missing( data ) ) {
     stop( 'a dataset of class data.table or data.frame must be provided' )
@@ -58,6 +69,9 @@ polish = function( data, data_key, pattern, time,
   }
   if ( missing( pattern ) ) {
     stop( "a pattern must be provided" )
+  }
+  if ( copy ) {
+    data = data.table::copy( data )
   }
   if ( inherits( data, 'data.frame' ) ) {
     setDT( data )

--- a/R/preprocess-helpers.R
+++ b/R/preprocess-helpers.R
@@ -1,0 +1,5 @@
+.msmtools_validate_flag = function( x, name ) {
+  if ( !is.logical( x ) || length( x ) != 1L || is.na( x ) ) {
+    stop( name, " must be either TRUE or FALSE" )
+  }
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![lifecycle](https://lifecycle.r-lib.org/articles/figures/lifecycle-stable.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![R-CMD-check](https://github.com/contefranz/msmtools/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/contefranz/msmtools/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/contefranz/msmtools/branch/main/graph/badge.svg?token=wDcJP6mRRY)](https://codecov.io/gh/contefranz/msmtools)
-[![release](https://img.shields.io/badge/dev.%20version-2.0.10-blue)](https://github.com/contefranz/msmtools)
+[![release](https://img.shields.io/badge/dev.%20version-2.1.0-blue)](https://github.com/contefranz/msmtools)
 [![CRAN Status Badge](https://www.r-pkg.org/badges/version/msmtools)](https://cran.r-project.org/package=msmtools)
 [![license](https://img.shields.io/badge/license-GPL--3-blue.svg)](https://en.wikipedia.org/wiki/GNU_General_Public_License)
 
@@ -61,6 +61,11 @@ hosp_augmented[
 
 `augment()` returns a `data.table`. Use `as.data.frame()` explicitly if a
 downstream workflow requires a plain `data.frame`.
+
+`augment()` and `polish()` use `copy = FALSE` by default to preserve the
+memory-efficient **data.table** workflow. This means input objects can be
+modified by reference. Set `copy = TRUE` when the original object must remain
+unchanged.
 
 
 #### Duplicate Transition Cleanup

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ hosp_augmented[
 `augment()` returns a `data.table`. Use `as.data.frame()` explicitly if a
 downstream workflow requires a plain `data.frame`.
 
+`pattern` describes the terminal outcome schema in the input data. `state`
+describes the generated transition-state labels and must contain three labels:
+the state at `t_start`, the state at `t_end`, and the absorbing state.
+
 `augment()` and `polish()` use `copy = FALSE` by default to preserve the
 memory-efficient **data.table** workflow. This means input objects can be
 modified by reference. Set `copy = TRUE` when the original object must remain

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -17,6 +17,7 @@ augment(
   t_augmented,
   more_status,
   check_NA = FALSE,
+  copy = FALSE,
   verbosity = getOption("msmtools.verbosity", "quiet")
 )
 }
@@ -78,6 +79,11 @@ intended for general consistency checks and the scan can add memory overhead
 on very large datasets. \code{more_status} is always checked for missing values
 when supplied.}
 
+\item{copy}{If \code{FALSE} (default), \code{augment()} keeps the historical
+memory-efficient behavior and may modify caller-owned \code{data} by reference.
+If \code{TRUE}, \code{data} is copied before any \code{data.table} operation so the input
+object remains unchanged.}
+
 \item{verbosity}{Controls informational output. Use \code{"quiet"} to suppress
 status messages, \code{"summary"} for high-level phase messages and timing, and
 \code{"progress"} for phase messages plus progress bars in long status-building
@@ -137,6 +143,12 @@ example, \code{"DEAD"}).
 \code{state}. Standard admissions that add no extra information should use \code{"df"}
 for "default" (see Examples, or run \code{?hosp} and inspect \code{rehab_it}). More
 complex transitions should use concise, self-explanatory labels.
+
+By default, \code{augment()} follows \strong{data.table} by-reference semantics to avoid
+unnecessary copies of large longitudinal datasets. This means the input may
+have its key changed, and \code{n_events} may be added when the argument is
+omitted. Set \code{copy = TRUE} when the original input object must remain
+unchanged.
 
 The function always returns a \code{data.table}. Use \code{\link[=as.data.frame]{as.data.frame()}} on the
 result if a plain \code{data.frame} is needed by downstream code.

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -9,13 +9,13 @@ augment(
   data_key,
   n_events,
   pattern,
-  state = list("IN", "OUT", "DEAD"),
+  state = c("IN", "OUT", "DEAD"),
   t_start,
   t_end,
   t_cens,
   t_death,
   t_augmented,
-  more_status,
+  more_status = NULL,
   check_NA = FALSE,
   copy = FALSE,
   verbosity = getOption("msmtools.verbosity", "quiet")
@@ -36,15 +36,15 @@ monotonically increasing within each \code{data_key} and stops if the check fail
 (see Details). If missing, \code{augment()} creates a variable named \code{"n_events"}.}
 
 \item{pattern}{Either an integer, a factor, or a character variable with 2 or
-3 unique values that gives each subject's status at the end of the study.
-\code{pattern} has a predefined structure. When 2 values are detected, they must
-be in the format: 0 = "alive", 1 = "dead". When 3 values are detected, they
-must be: 0 = "alive", 1 = "dead during a transition", 2 = "dead after a
-transition has ended" (see Details).}
-
-\item{state}{A list of exactly three possible states that a subject can
-reach. \code{state} has a predefined structure: \code{IN}, \code{OUT}, \code{DEAD}
+3 unique values that gives each subject's terminal outcome schema. When 2
+values are detected, they must be in the format: 0 = "alive", 1 = "dead".
+When 3 values are detected, they must be: 0 = "alive",
+1 = "dead during a transition", 2 = "dead after a transition has ended"
 (see Details).}
+
+\item{state}{A character vector of exactly three unique, non-missing,
+non-empty labels used as the generated transition-state vocabulary.
+Defaults to \code{c("IN", "OUT", "DEAD")} (see Details).}
 
 \item{t_start}{The starting time of an observation. It can be passed as date,
 integer, or numeric format.}
@@ -70,7 +70,7 @@ date or difftime variables directly. Both variables are positioned before
 
 \item{more_status}{A variable that marks further transitions beyond the
 default ones given by \code{state}. \code{more_status} can be a factor or character
-(see Details). If missing, \code{augment()} ignores it.}
+(see Details). If \code{NULL} (default), \code{augment()} ignores it.}
 
 \item{check_NA}{If \code{TRUE}, \code{data_key}, \code{n_events}, \code{pattern}, \code{t_start}, and
 \code{t_end} are checked for missing values. If any missing values are found, the
@@ -127,17 +127,20 @@ subjects that violate the condition. If \code{n_events} is missing, \code{augmen
 first computes a progression number named \emph{n_events} and then runs the same
 check.
 
-Argument \code{pattern} must follow the expected ordering. With two statuses,
-values must correspond to \code{0 = "alive"} and \code{1 = "dead"}. With three
-statuses, integer values must correspond to \code{0 = "alive"},
-\code{1 = "dead inside a transition"}, and
+Argument \code{pattern} describes the terminal outcome schema and must follow the
+expected ordering. With two statuses, values must correspond to
+\code{0 = "alive"} and \code{1 = "dead"}. With three statuses, integer values must
+correspond to \code{0 = "alive"}, \code{1 = "dead inside a transition"}, and
 \code{2 = "dead outside a transition"}. Character and factor values must follow
 the same order. For example, \code{0} cannot be used to indicate death.
 
-The order of \code{state} also matters. The first element is the state at
-\code{t_start} (for example, \code{"IN"}), the second element is the state at \code{t_end}
-(for example, \code{"OUT"}), and the third element is the absorbing state (for
-example, \code{"DEAD"}).
+Argument \code{state} describes the generated transition-state vocabulary. Its
+order also matters. The first element is the state at \code{t_start} (for example,
+\code{"IN"}), the second element is the state at \code{t_end} (for example, \code{"OUT"}),
+and the third element is the absorbing state (for example, \code{"DEAD"}). A
+two-value \code{pattern} still requires three \code{state} labels because \code{augment()}
+infers whether death maps to the absorbing state inside or outside the
+transition window.
 
 \code{more_status} lets \code{augment()} represent transitions beyond the defaults in
 \code{state}. Standard admissions that add no extra information should use \code{"df"}

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -178,7 +178,7 @@ hosp_augmented = augment( data = hosp, data_key = subj, n_events = adm_number,
 Grossetti, F., Ieva, F., and Paganoni, A.M. (2018).
 A multi-state approach to patients affected by chronic heart failure.
 \emph{Health Care Management Science}, 21, 281-291.
-\url{https://doi.org/10.1007/s10729-017-9400-z}.
+\doi{10.1007/s10729-017-9400-z}.
 
 Jackson, C.H. (2011). Multi-State Models for Panel Data: The
 \strong{msm} Package for R. Journal of Statistical Software, 38(8), 1-29.

--- a/man/polish.Rd
+++ b/man/polish.Rd
@@ -10,6 +10,7 @@ polish(
   pattern,
   time,
   check_NA = FALSE,
+  copy = FALSE,
   verbosity = getOption("msmtools.verbosity", "quiet")
 )
 }
@@ -36,6 +37,11 @@ By default it is set to \code{"augmented_int"}.}
 missing values. If any missing values are found, the function stops with an
 error. Default is \code{FALSE}.}
 
+\item{copy}{If \code{FALSE} (default), \code{polish()} keeps the historical
+memory-efficient behavior and may modify caller-owned \code{data} by reference.
+If \code{TRUE}, \code{data} is copied before any \code{data.table} operation so the input
+object remains unchanged.}
+
 \item{verbosity}{Controls informational output. Use \code{"quiet"} to suppress
 status messages, \code{"summary"} for high-level phase messages and timing, and
 \code{"progress"} for phase messages plus progress bars in long status-building
@@ -50,6 +56,11 @@ The function searches for cases where two subsequent events for the
 same subject land on different states but occur at the same time. When this
 happens, the whole subject, as identified by \code{data_key}, is removed from the
 data. The function reports how many subjects were removed.
+
+By default, \code{polish()} follows \strong{data.table} by-reference semantics to avoid
+unnecessary copies of large augmented datasets. This means the input may have
+its key changed while duplicate subjects are identified. Set \code{copy = TRUE}
+when the original input object must remain unchanged.
 
 The function always returns a \code{data.table}. Use \code{\link[=as.data.frame]{as.data.frame()}} on the
 result if a plain \code{data.frame} is needed by downstream code.

--- a/man/polish.Rd
+++ b/man/polish.Rd
@@ -24,11 +24,11 @@ times. If \code{data} is a \code{data.frame}, \code{augment()} internally casts 
 for \code{data} (see \code{\link[data.table:setkey]{data.table::setkey()}}).}
 
 \item{pattern}{Either an integer, a factor, or a character variable with 2 or
-3 unique values that gives each subject's status at the end of the study.
-\code{pattern} has a predefined structure. When 2 values are detected, they must
-be in the format: 0 = "alive", 1 = "dead". When 3 values are detected, they
-must be: 0 = "alive", 1 = "dead during a transition", 2 = "dead after a
-transition has ended" (see Details).}
+3 unique values that gives each subject's terminal outcome schema. When 2
+values are detected, they must be in the format: 0 = "alive", 1 = "dead".
+When 3 values are detected, they must be: 0 = "alive",
+1 = "dead during a transition", 2 = "dead after a transition has ended"
+(see Details).}
 
 \item{time}{The time variable used to identify duplicate transition times.
 By default it is set to \code{"augmented_int"}.}

--- a/tests/testthat/test-augment.R
+++ b/tests/testthat/test-augment.R
@@ -22,7 +22,7 @@ test_that( "augment validates required inputs and state shape", {
   expect_error(
     augment( test_hosp(), subj, adm_number, label_3, state = list( "IN" ),
              t_start = dateIN, t_end = dateOUT, t_cens = dateCENS ),
-    "state pattern"
+    "state must be a character vector"
   )
   expect_error(
     augment( test_hosp(), subj, adm_number, label_3, t_end = dateOUT,
@@ -70,6 +70,54 @@ test_that( "missing n_events is reconstructed from subject order", {
   )
 
   expect_identical( hosp_aug$adm_number, hosp_aug_no_events$n_events )
+} )
+
+test_that( "state must be a valid character vector", {
+  expect_error(
+    augment( test_hosp(), subj, adm_number, label_3,
+             state = list( "IN", "OUT", "DEAD" ), t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    "state must be a character vector"
+  )
+  expect_error(
+    augment( test_hosp(), subj, adm_number, label_3,
+             state = c( "IN", "OUT" ), t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    "state must be a character vector"
+  )
+  expect_error(
+    augment( test_hosp(), subj, adm_number, label_3,
+             state = c( "IN", NA, "DEAD" ), t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    "state must be a character vector"
+  )
+  expect_error(
+    augment( test_hosp(), subj, adm_number, label_3,
+             state = c( "IN", "", "DEAD" ), t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    "state must be a character vector"
+  )
+  expect_error(
+    augment( test_hosp(), subj, adm_number, label_3,
+             state = c( "IN", "IN", "DEAD" ), t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    "state must be a character vector"
+  )
+} )
+
+test_that( "state vector controls generated transition labels", {
+  custom_state = c( "ENTRY", "EXIT", "ABSORBING" )
+  hosp_aug_3 = augment_hosp( state = custom_state, pattern = "label_3" )
+  hosp_aug_2 = augment_hosp( state = custom_state, pattern = "label_2" )
+
+  expect_true( all( hosp_aug_3$status %in% custom_state ) )
+  expect_true( all( hosp_aug_2$status %in% custom_state ) )
+  expect_true( all( custom_state %in% hosp_aug_3$status ) )
+  expect_true( all( custom_state %in% hosp_aug_2$status ) )
+  expect_true( all( hosp_aug_3$n_status[ hosp_aug_3$status == "ABSORBING" ] ==
+                      "ABSORBING" ) )
+  expect_true( all( hosp_aug_2$n_status[ hosp_aug_2$status == "ABSORBING" ] ==
+                      "ABSORBING" ) )
 } )
 
 test_that( "check_NA catches missing values and passes clean data", {
@@ -228,4 +276,8 @@ test_that( "more_status creates expanded status columns", {
   expect_false( anyNA( hosp_aug$status_exp ) )
   expect_false( anyNA( hosp_aug$status_exp_num ) )
   expect_false( anyNA( hosp_aug$n_status_exp ) )
+} )
+
+test_that( "explicit NULL more_status matches omitted more_status", {
+  expect_identical( augment_hosp(), augment_hosp( more_status = NULL ) )
 } )

--- a/tests/testthat/test-augment.R
+++ b/tests/testthat/test-augment.R
@@ -129,6 +129,21 @@ test_that( "verbosity controls informational output", {
   )
 } )
 
+test_that( "copy validates logical flags", {
+  expect_error(
+    augment( test_hosp(), subj, adm_number, label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS,
+             copy = "yes" ),
+    "copy must be either TRUE or FALSE"
+  )
+  expect_error(
+    augment( test_hosp(), subj, adm_number, label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS,
+             check_NA = NA ),
+    "check_NA must be either TRUE or FALSE"
+  )
+} )
+
 test_that( "Date inputs create integer augmented time", {
   hosp_aug = augment_hosp( t_augmented = event_time )
 

--- a/tests/testthat/test-invariants.R
+++ b/tests/testthat/test-invariants.R
@@ -75,6 +75,39 @@ test_that( "augment current by-reference behavior is documented by tests", {
   expect_identical( data.table::key( input ), "subj" )
 } )
 
+test_that( "augment copy protects caller-owned data", {
+  input = test_hosp()
+  before_names = data.table::copy( names( input ) )
+  before_key = data.table::copy( data.table::key( input ) )
+
+  out = suppressWarnings(
+    augment( input, subj, pattern = label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, copy = TRUE )
+  )
+
+  expect_identical( names( input ), before_names )
+  expect_identical( data.table::key( input ), before_key )
+  expect_false( "n_events" %in% names( input ) )
+  expect_true( "n_events" %in% names( out ) )
+  expect_s3_class( out, "data.table" )
+} )
+
+test_that( "augment copy protects data.frame inputs", {
+  input = as.data.frame( test_hosp() )
+  before_names = names( input )
+  before_class = class( input )
+
+  out = suppressWarnings(
+    augment( input, subj, adm_number, label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, copy = TRUE )
+  )
+
+  expect_identical( names( input ), before_names )
+  expect_identical( class( input ), before_class )
+  expect_false( inherits( input, "data.table" ) )
+  expect_s3_class( out, "data.table" )
+} )
+
 test_that( "polish current by-reference behavior is documented by tests", {
   input = augment_hosp()
   before_names = data.table::copy( names( input ) )
@@ -85,4 +118,17 @@ test_that( "polish current by-reference behavior is documented by tests", {
   expect_identical( names( input ), before_names )
   expect_false( identical( before_key, data.table::key( input ) ) )
   expect_identical( data.table::key( input ), "subj" )
+} )
+
+test_that( "polish copy protects caller-owned data", {
+  input = augment_hosp()
+  before_names = data.table::copy( names( input ) )
+  before_key = data.table::copy( data.table::key( input ) )
+
+  out = polish( input, subj, label_3, copy = TRUE )
+
+  expect_identical( names( input ), before_names )
+  expect_identical( data.table::key( input ), before_key )
+  expect_false( "index" %in% names( input ) )
+  expect_s3_class( out, "data.table" )
 } )

--- a/tests/testthat/test-polish.R
+++ b/tests/testthat/test-polish.R
@@ -26,3 +26,16 @@ test_that( "polish returns a data.table", {
   expect_s3_class( hosp_clean, "data.table" )
   expect_s3_class( as.data.frame( hosp_clean ), "data.frame" )
 } )
+
+test_that( "polish validates logical flags", {
+  hosp_aug = augment_hosp()
+
+  expect_error(
+    polish( data.table::copy( hosp_aug ), subj, label_3, copy = "yes" ),
+    "copy must be either TRUE or FALSE"
+  )
+  expect_error(
+    polish( data.table::copy( hosp_aug ), subj, label_3, check_NA = NA ),
+    "check_NA must be either TRUE or FALSE"
+  )
+} )

--- a/vignettes/msmtools.Rmd
+++ b/vignettes/msmtools.Rmd
@@ -72,11 +72,19 @@ with numeric time scales.
 names(hosp_augmented)
 ```
 
+By default, `augment()` uses `copy = FALSE` and follows **data.table**
+by-reference semantics. This avoids unnecessary memory use on large longitudinal
+datasets, but the input object can have its key changed and `n_events` can be
+created when the argument is omitted. Use `copy = TRUE` when the original input
+must remain unchanged.
+
 # Duplicate Transition Cleanup
 
 `polish()` removes entire subjects when different transitions occur at the same
 time. The bundled data do not contain such conflicts, so this call leaves the
-data unchanged.
+data unchanged. It also uses `copy = FALSE` by default; set `copy = TRUE` when
+the original augmented data should not be keyed or otherwise touched by
+reference.
 
 ```{r polish}
 hosp_clean <- polish(

--- a/vignettes/msmtools.Rmd
+++ b/vignettes/msmtools.Rmd
@@ -72,6 +72,19 @@ with numeric time scales.
 names(hosp_augmented)
 ```
 
+# Outcome Schema And Generated States
+
+`pattern` and `state` describe different parts of the augmentation. `pattern`
+is the terminal outcome schema observed in the input data. It can have two
+values, alive and dead, or three values, alive, dead during a transition, and
+dead after a transition.
+
+`state` is the generated transition-state vocabulary. It must always contain
+three labels: the state at `t_start`, the state at `t_end`, and the absorbing
+state. This is why a two-value `pattern` still needs three `state` labels:
+`augment()` uses the event times to infer whether death maps to the absorbing
+state inside or outside the transition window.
+
 By default, `augment()` uses `copy = FALSE` and follows **data.table**
 by-reference semantics. This avoids unnecessary memory use on large longitudinal
 datasets, but the input object can have its key changed and `n_events` can be


### PR DESCRIPTION
Improved `augment()` API
- `state` is now intentionally stricter: character vector only, no list input.
- `copy` is the new compatibility bridge: default `FALSE` preserves current by-reference behavior, while `TRUE` protects caller-owned data.