### PR TITLE
Dev/v2.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: msmtools
 Type: Package
 Title: Building Augmented Data to Run Multi-State Models with 'msm' Package
-Version: 2.1.0
-Date: 2026-05-25
+Version: 2.1.1
+Date: 2026-05-26
 Authors@R: person("Francesco", "Grossetti",
     email = "francesco.grossetti@unibocconi.it",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0002-5130-7745"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,27 @@
+# msmtools 2.1.1
+***
+
+### CHANGES
+
+* Made `polish()` time-column handling explicit. Omitting `time` or setting
+  `time = NULL` now auto-detects `augmented_int`, then `augmented_num`; calls
+  error clearly when neither column is available.
+
+* Replaced remaining `polish()` console output with the shared `cli` verbosity
+  helpers used by `augment()`.
+
+* Added clearer validation for `polish()` inputs, including missing columns and
+  terminal outcome schemas with anything other than 2 or 3 unique values.
+
+### DOCUMENTATION
+
+* Documented the `polish()` time-column auto-detection behavior.
+
+### TESTS
+
+* Added regression coverage for `polish()` time resolution, missing columns,
+  invalid pattern schemas, missing-value checks, and summary verbosity.
+
 # msmtools 2.1.0
 ***
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 * Replaced remaining `polish()` console output with the shared `cli` verbosity
   helpers used by `augment()`.
 
+* Qualified `polish()` calls to external **data.table** functions explicitly
+  instead of relying on roxygen imports.
+
 * Added clearer validation for `polish()` inputs, including missing columns and
   terminal outcome schemas with anything other than 2 or 3 unique values.
 

--- a/R/polish.R
+++ b/R/polish.R
@@ -1,5 +1,5 @@
-if ( getRversion() >= "2.15.1" ) {
-  utils::globalVariables( c( ":=", ".I", ".N", "index" ) )
+if (getRversion() >= "2.15.1") {
+  utils::globalVariables(c(":=", ".I", ".N", "index"))
 }
 
 #' Remove observations with different states occurring at the same time
@@ -38,109 +38,109 @@ if ( getRversion() >= "2.15.1" ) {
 #' @examples
 #'
 #' # loading data
-#' data( hosp )
+#' data(hosp)
 #'
 #' # augmenting longitudinal data
-#' hosp_aug = augment( data = hosp, data_key = subj, n_events = adm_number,
-#'                     pattern = label_3, t_start = dateIN, t_end = dateOUT,
-#'                     t_cens = dateCENS )
+#' hosp_aug = augment(data = hosp, data_key = subj, n_events = adm_number,
+#'                    pattern = label_3, t_start = dateIN, t_end = dateOUT,
+#'                    t_cens = dateCENS)
 #'
 #' # cleaning targeted duplicate transitions
-#' hosp_aug_clean = polish( data = hosp_aug, data_key = subj, pattern = label_3 )
+#' hosp_aug_clean = polish(data = hosp_aug, data_key = subj, pattern = label_3)
 #'
 #' @author Francesco Grossetti <francesco.grossetti@unibocconi.it>.
 #' @importFrom data.table setDT setkey setkeyv rbindlist uniqueN
 #' @export
 
-polish = function( data, data_key, pattern, time = NULL, check_NA = FALSE,
-                   copy = FALSE,
-                   verbosity = getOption( "msmtools.verbosity", "quiet" ) ) {
+polish = function(data, data_key, pattern, time = NULL, check_NA = FALSE,
+                  copy = FALSE,
+                  verbosity = getOption("msmtools.verbosity", "quiet")) {
 
   tic = proc.time()
-  verbosity = .msmtools_verbosity( verbosity )
-  .msmtools_validate_flag( copy, "copy" )
-  .msmtools_validate_flag( check_NA, "check_NA" )
+  verbosity = .msmtools_verbosity(verbosity)
+  .msmtools_validate_flag(copy, "copy")
+  .msmtools_validate_flag(check_NA, "check_NA")
 
-  if ( missing( data ) ) {
-    stop( 'a dataset of class data.table or data.frame must be provided' )
+  if (missing(data)) {
+    stop('a dataset of class data.table or data.frame must be provided')
   }
-  if ( !inherits( data, "data.table" ) && !inherits( data, "data.frame" ) ) {
-    stop( "a dataset of class data.table or data.frame must be provided" )
+  if (!inherits(data, "data.table") && !inherits(data, "data.frame")) {
+    stop("a dataset of class data.table or data.frame must be provided")
   }
-  if ( missing( data_key ) ) {
-    stop( 'a variable of keying must be provided' )
+  if (missing(data_key)) {
+    stop('a variable of keying must be provided')
   }
-  if ( missing( pattern ) ) {
-    stop( "a pattern must be provided" )
+  if (missing(pattern)) {
+    stop("a pattern must be provided")
   }
-  if ( copy ) {
-    data = data.table::copy( data )
+  if (copy) {
+    data = data.table::copy(data)
   }
-  if ( inherits( data, 'data.frame' ) ) {
-    setDT( data )
+  if (inherits(data, 'data.frame')) {
+    setDT(data)
   }
-  .msmtools_cli_rule( verbosity, "setting everything up" )
+  .msmtools_cli_rule(verbosity, "setting everything up")
 
-  setkey( data, NULL )
-  cols = as.character( substitute( data_key ) )
-  if ( !length( cols ) ) {
-    cols = colnames( data )
+  setkey(data, NULL)
+  cols = as.character(substitute(data_key))
+  if (!length(cols)) {
+    cols = colnames(data)
   }
-  pattern = as.character( substitute( pattern ) )
-  time_arg = substitute( time )
-  if ( missing( time ) || is.null( time_arg ) ) {
-    time = .polish_resolve_time( data )
-    .msmtools_cli_info( verbosity, paste0( time, " set as time variable" ) )
+  pattern = as.character(substitute(pattern))
+  time_arg = substitute(time)
+  if (missing(time) || is.null(time_arg)) {
+    time = .polish_resolve_time(data)
+    .msmtools_cli_info(verbosity, paste0(time, " set as time variable"))
   } else {
-    time = as.character( time_arg )
+    time = as.character(time_arg)
   }
-  .polish_check_columns( data, c( cols, pattern, time ) )
-  setkeyv( data, cols )
+  .polish_check_columns(data, c(cols, pattern, time))
+  setkeyv(data, cols)
 
-  if ( isTRUE( check_NA ) ) {
+  if (isTRUE(check_NA)) {
     .msmtools_cli_info(
       verbosity,
       "checking for any missing values in function arguments"
     )
-    checks = c( cols, pattern, time )
-    test = apply( data[ , checks, with = FALSE ], 2,
-                  function( x ) any( sum( is.na( x ) ) > 0 ) )
-    if ( any ( test ) ) {
-      missing_values = paste( names( test[ test == TRUE ] ), collapse = ", " )
-      stop( paste0( "missing values detected in: ", missing_values ) )
+    checks = c(cols, pattern, time)
+    test = apply(data[, checks, with = FALSE], 2,
+                 function(x) any(sum(is.na(x)) > 0))
+    if (any(test)) {
+      missing_values = paste(names(test[test == TRUE]), collapse = ", ")
+      stop(paste0("missing values detected in: ", missing_values))
     } else {
-      .msmtools_cli_success( verbosity, "no missing values detected" )
+      .msmtools_cli_success(verbosity, "no missing values detected")
     }
   }
 
-  data[ , index := sequence( .N ) ]
-  n_patients = uniqueN( data[[ cols[[ 1 ]] ]] )
-  values = .polish_pattern_values( data, pattern, verbosity )
+  data[, index := sequence(.N)]
+  n_patients = uniqueN(data[[cols[[1]]]])
+  values = .polish_pattern_values(data, pattern, verbosity)
 
-  alive = data[ get( pattern ) == values[ 1 ] ]
-  alive.last = alive[ alive[ , .I[ .N ], by = eval( cols ) ]$V1 ]
-  setkey( alive.last, index )
-  setkey( alive, index )
-  alive.no.last = alive[ !alive.last ]
+  alive = data[get(pattern) == values[1]]
+  alive.last = alive[alive[, .I[.N], by = eval(cols)]$V1]
+  setkey(alive.last, index)
+  setkey(alive, index)
+  alive.no.last = alive[!alive.last]
 
-  if ( length( values ) == 2 ) {
-    dead = data[ get( pattern ) == values[ 2 ] ]
-  } else if ( length( values ) == 3 ) {
-    dead = data[ get( pattern ) != values[ 1 ] ]
+  if (length(values) == 2) {
+    dead = data[get(pattern) == values[2]]
+  } else if (length(values) == 3) {
+    dead = data[get(pattern) != values[1]]
   }
 
-  l = list( alive.no.last, dead )
-  data.no.last.event = rbindlist( l )
-  row.duplicated = duplicated( data.no.last.event,
-                               by = c( eval( cols ), eval( time ) ) )
-  duplicated = data.no.last.event[ row.duplicated == TRUE ]
-  n_duplicated = uniqueN( duplicated[[ cols[[ 1 ]] ]] )
-  setkeyv( duplicated, cols )
+  l = list(alive.no.last, dead)
+  data.no.last.event = rbindlist(l)
+  row.duplicated = duplicated(data.no.last.event,
+                              by = c(eval(cols), eval(time)))
+  duplicated = data.no.last.event[row.duplicated == TRUE]
+  n_duplicated = uniqueN(duplicated[[cols[[1]]]])
+  setkeyv(duplicated, cols)
 
-  if ( n_duplicated == 0 ) {
+  if (n_duplicated == 0) {
     .msmtools_cli_success(
       verbosity,
-      paste0( "no duplicated occurrences found according to ", time )
+      paste0("no duplicated occurrences found according to ", time)
     )
   } else {
     .msmtools_cli_info(
@@ -150,13 +150,13 @@ polish = function( data, data_key, pattern, time = NULL, check_NA = FALSE,
         " subjects with at least one duplicated occurrence according to ", time
       )
     )
-    data.clean = data[ !duplicated ]
-    n_patients.to.keep = uniqueN( data.clean[[ cols[[ 1 ]] ]] )
+    data.clean = data[!duplicated]
+    n_patients.to.keep = uniqueN(data.clean[[cols[[1]]]])
     .msmtools_cli_success(
       verbosity,
       paste0(
         n_patients.to.keep, " subjects retained, corresponding to ",
-        round( 100 * ( n_patients.to.keep / n_patients ), 2 ), "%"
+        round(100 * (n_patients.to.keep / n_patients), 2), "%"
       )
     )
     .msmtools_cli_success(
@@ -165,22 +165,22 @@ polish = function( data, data_key, pattern, time = NULL, check_NA = FALSE,
     )
   }
 
-  data[ , index := NULL ]
-  if ( n_duplicated > 0 ) {
-    data.clean[ , index := NULL ]
+  data[, index := NULL]
+  if (n_duplicated > 0) {
+    data.clean[, index := NULL]
   }
   elapsed = proc.time() - tic
   .msmtools_cli_rule(
     verbosity,
-    paste0( "polish() took: ", elapsed[ 3 ], " sec." )
+    paste0("polish() took: ", elapsed[3], " sec.")
   )
 
-  if ( n_duplicated == 0 ) {
+  if (n_duplicated == 0) {
     data[]
-    return( data )
+    return(data)
   }
   data.clean[]
-  return( data.clean )
+  return(data.clean)
 }
 
 #' Resolve the default duplicate-time column for `polish()`
@@ -190,14 +190,14 @@ polish = function( data, data_key, pattern, time = NULL, check_NA = FALSE,
 #'
 #' @keywords internal
 #' @noRd
-.polish_resolve_time = function( data ) {
-  if ( "augmented_int" %in% names( data ) ) {
-    return( "augmented_int" )
+.polish_resolve_time = function(data) {
+  if ("augmented_int" %in% names(data)) {
+    return("augmented_int")
   }
-  if ( "augmented_num" %in% names( data ) ) {
-    return( "augmented_num" )
+  if ("augmented_num" %in% names(data)) {
+    return("augmented_num")
   }
-  stop( "time must be provided when data does not contain augmented_int or augmented_num" )
+  stop("time must be provided when data does not contain augmented_int or augmented_num")
 }
 
 #' Check that required `polish()` columns exist
@@ -207,13 +207,13 @@ polish = function( data, data_key, pattern, time = NULL, check_NA = FALSE,
 #'
 #' @keywords internal
 #' @noRd
-.polish_check_columns = function( data, columns ) {
-  missing_columns = setdiff( columns, names( data ) )
-  if ( length( missing_columns ) ) {
+.polish_check_columns = function(data, columns) {
+  missing_columns = setdiff(columns, names(data))
+  if (length(missing_columns)) {
     stop(
       paste0(
         "the following columns are not present in data: ",
-        paste( missing_columns, collapse = ", " )
+        paste(missing_columns, collapse = ", ")
       )
     )
   }
@@ -226,18 +226,18 @@ polish = function( data, data_key, pattern, time = NULL, check_NA = FALSE,
 #'
 #' @keywords internal
 #' @noRd
-.polish_pattern_values = function( data, pattern, verbosity ) {
-  values = sort( unique( data[[ pattern ]] ) )
-  if ( !length( values ) %in% 2:3 ) {
-    stop( "pattern must have 2 or 3 unique values" )
+.polish_pattern_values = function(data, pattern, verbosity) {
+  values = sort(unique(data[[pattern]]))
+  if (!length(values) %in% 2:3) {
+    stop("pattern must have 2 or 3 unique values")
   }
   .msmtools_cli_info(
     verbosity,
-    paste0( "checking ", pattern, " and defining patterns" )
+    paste0("checking ", pattern, " and defining patterns")
   )
   .msmtools_cli_success(
     verbosity,
-    paste0( "detected ", length( values ), " values in ", pattern )
+    paste0("detected ", length(values), " values in ", pattern)
   )
   values
 }

--- a/R/polish.R
+++ b/R/polish.R
@@ -1,6 +1,45 @@
 if ( getRversion() >= "2.15.1" ) {
   utils::globalVariables( c( ":=", ".I", ".N", "index" ) )
 }
+
+.polish_resolve_time = function( data ) {
+  if ( "augmented_int" %in% names( data ) ) {
+    return( "augmented_int" )
+  }
+  if ( "augmented_num" %in% names( data ) ) {
+    return( "augmented_num" )
+  }
+  stop( "time must be provided when data does not contain augmented_int or augmented_num" )
+}
+
+.polish_check_columns = function( data, columns ) {
+  missing_columns = setdiff( columns, names( data ) )
+  if ( length( missing_columns ) ) {
+    stop(
+      paste0(
+        "the following columns are not present in data: ",
+        paste( missing_columns, collapse = ", " )
+      )
+    )
+  }
+}
+
+.polish_pattern_values = function( data, pattern, verbosity ) {
+  values = sort( unique( data[[ pattern ]] ) )
+  if ( !length( values ) %in% 2:3 ) {
+    stop( "pattern must have 2 or 3 unique values" )
+  }
+  .msmtools_cli_info(
+    verbosity,
+    paste0( "checking ", pattern, " and defining patterns" )
+  )
+  .msmtools_cli_success(
+    verbosity,
+    paste0( "detected ", length( values ), " values in ", pattern )
+  )
+  values
+}
+
 #' Remove observations with different states occurring at the same time
 #'
 #' Remove subjects with transitions to different states occurring at the same
@@ -8,7 +47,9 @@ if ( getRversion() >= "2.15.1" ) {
 #'
 #' @inheritParams augment
 #' @param time The time variable used to identify duplicate transition times.
-#' By default it is set to `"augmented_int"`.
+#' If omitted or set to `NULL`, `polish()` uses `"augmented_int"` when it is
+#' available, then `"augmented_num"`. If neither column exists, `time` must be
+#' supplied explicitly.
 #' @param check_NA If `TRUE`, `data_key`, `pattern`, and `time` are checked for
 #' missing values. If any missing values are found, the function stops with an
 #' error. Default is `FALSE`.
@@ -49,7 +90,7 @@ if ( getRversion() >= "2.15.1" ) {
 #' @importFrom data.table setDT setkey setkeyv rbindlist uniqueN
 #' @export
 
-polish = function( data, data_key, pattern, time, check_NA = FALSE,
+polish = function( data, data_key, pattern, time = NULL, check_NA = FALSE,
                    copy = FALSE,
                    verbosity = getOption( "msmtools.verbosity", "quiet" ) ) {
 
@@ -76,66 +117,43 @@ polish = function( data, data_key, pattern, time, check_NA = FALSE,
   if ( inherits( data, 'data.frame' ) ) {
     setDT( data )
   }
-  if ( .msmtools_is_summary( verbosity ) ) {
-    cat( '-------------------------------------\n' )
-    cat( '# # # # setting everything up # # # #\n' )
-    cat( '-------------------------------------\n' )
-  }
+  .msmtools_cli_rule( verbosity, "setting everything up" )
 
   setkey( data, NULL )
   cols = as.character( substitute( data_key ) )
   if ( !length( cols ) ) {
     cols = colnames( data )
   }
-  setkeyv( data, cols )
   pattern = as.character( substitute( pattern ) )
-  if ( missing( time ) ) {
-    if ( "augmented_int" %in% names( data ) ) {
-      if ( .msmtools_is_summary( verbosity ) ) {
-        cat( "augmented_int set as time variable\n" )
-        cat( "---\n" )
-      }
-      time = 'augmented_int'
-    } else if ( "augmented_num" %in% names( data ) ) {
-      if ( .msmtools_is_summary( verbosity ) ) {
-        cat( "augmented_num set as time variable\n" )
-        cat( "---\n" )
-      }
-      time = 'augmented_num'
-    }
+  time_arg = substitute( time )
+  if ( missing( time ) || is.null( time_arg ) ) {
+    time = .polish_resolve_time( data )
+    .msmtools_cli_info( verbosity, paste0( time, " set as time variable" ) )
   } else {
-    time = as.character( substitute( time ) )
+    time = as.character( time_arg )
   }
+  .polish_check_columns( data, c( cols, pattern, time ) )
+  setkeyv( data, cols )
 
-  if ( check_NA == TRUE ) {
-    if ( .msmtools_is_summary( verbosity ) ) {
-      message( 'checking for any missing values in function arguments' )
-    }
+  if ( isTRUE( check_NA ) ) {
+    .msmtools_cli_info(
+      verbosity,
+      "checking for any missing values in function arguments"
+    )
     checks = c( cols, pattern, time )
     test = apply( data[ , checks, with = FALSE ], 2,
                   function( x ) any( sum( is.na( x ) ) > 0 ) )
     if ( any ( test ) ) {
-      if ( .msmtools_is_summary( verbosity ) ) {
-        message( 'detected missing values in the following variables:' )
-        invisible( sapply( names( test[ test == TRUE ] ),
-                           function( x ) cat( x, '\n' ) ) )
-      }
-      stop( 'Please, fix the issues and relaunch polish()' )
+      missing_values = paste( names( test[ test == TRUE ] ), collapse = ", " )
+      stop( paste0( "missing values detected in: ", missing_values ) )
     } else {
-      if ( .msmtools_is_summary( verbosity ) ) {
-        cat( 'Ok, no missing values detected\n')
-        cat( '---\n' )
-      }
+      .msmtools_cli_success( verbosity, "no missing values detected" )
     }
   }
 
   data[ , index := sequence( .N ) ]
   n_patients = uniqueN( data[[ cols[[ 1 ]] ]] )
-  values = sort( unique( data[[ pattern ]] ) )
-  if ( length( values ) < 2 ) {
-    stop( 'unit identification label must be an integer,
-          a factor or a character with at least 2 elements' )
-  }
+  values = .polish_pattern_values( data, pattern, verbosity )
 
   alive = data[ get( pattern ) == values[ 1 ] ]
   alive.last = alive[ alive[ , .I[ .N ], by = eval( cols ) ]$V1 ]
@@ -143,20 +161,9 @@ polish = function( data, data_key, pattern, time, check_NA = FALSE,
   setkey( alive, index )
   alive.no.last = alive[ !alive.last ]
 
-  if ( .msmtools_is_summary( verbosity ) ) {
-    message( 'checking ', pattern, ' and defining patterns' )
-  }
   if ( length( values ) == 2 ) {
-    if ( .msmtools_is_summary( verbosity ) ) {
-      cat( 'detected only 2 values\n' )
-      cat( '---\n' )
-    }
     dead = data[ get( pattern ) == values[ 2 ] ]
   } else if ( length( values ) == 3 ) {
-    if ( .msmtools_is_summary( verbosity ) ) {
-      cat( 'Ok, detected 3 values\n' )
-      cat( '---\n' )
-    }
     dead = data[ get( pattern ) != values[ 1 ] ]
   }
 
@@ -169,36 +176,42 @@ polish = function( data, data_key, pattern, time, check_NA = FALSE,
   setkeyv( duplicated, cols )
 
   if ( n_duplicated == 0 ) {
-    if ( .msmtools_is_summary( verbosity ) ) {
-      cat( 'Hurray! No duplicated occurrences have been found according to variable ',
-           time, "\n", sep = "" )
-    }
+    .msmtools_cli_success(
+      verbosity,
+      paste0( "no duplicated occurrences found according to ", time )
+    )
   } else {
-    if ( .msmtools_is_summary( verbosity ) ) {
-      message( 'Spotted ', n_duplicated,
-               ' patients with at least a duplicated occurrence according to variable ',
-               time )
-    }
+    .msmtools_cli_info(
+      verbosity,
+      paste0(
+        "spotted ", n_duplicated,
+        " subjects with at least one duplicated occurrence according to ", time
+      )
+    )
     data.clean = data[ !duplicated ]
     n_patients.to.keep = uniqueN( data.clean[[ cols[[ 1 ]] ]] )
-    if ( .msmtools_is_summary( verbosity ) ) {
-      cat( n_patients.to.keep, ' patients have been reained corresponding to ',
-           round( 100 * ( n_patients.to.keep / n_patients ), 2 ), '%\n', sep = '' )
-      cat( 'Duplicated patients have been successfully removed\n' )
-    }
+    .msmtools_cli_success(
+      verbosity,
+      paste0(
+        n_patients.to.keep, " subjects retained, corresponding to ",
+        round( 100 * ( n_patients.to.keep / n_patients ), 2 ), "%"
+      )
+    )
+    .msmtools_cli_success(
+      verbosity,
+      "duplicated subjects have been successfully removed"
+    )
   }
 
   data[ , index := NULL ]
   if ( n_duplicated > 0 ) {
     data.clean[ , index := NULL ]
   }
-  toc = proc.time()
-  time = toc - tic
-  if ( .msmtools_is_summary( verbosity ) ) {
-    cat( '---------------------------\n' )
-    cat( 'polish() took:', time[ 3 ], 'sec. \n', sep = ' ' )
-    cat( '---------------------------\n' )
-  }
+  elapsed = proc.time() - tic
+  .msmtools_cli_rule(
+    verbosity,
+    paste0( "polish() took: ", elapsed[ 3 ], " sec." )
+  )
 
   if ( n_duplicated == 0 ) {
     data[]

--- a/R/polish.R
+++ b/R/polish.R
@@ -2,44 +2,6 @@ if ( getRversion() >= "2.15.1" ) {
   utils::globalVariables( c( ":=", ".I", ".N", "index" ) )
 }
 
-.polish_resolve_time = function( data ) {
-  if ( "augmented_int" %in% names( data ) ) {
-    return( "augmented_int" )
-  }
-  if ( "augmented_num" %in% names( data ) ) {
-    return( "augmented_num" )
-  }
-  stop( "time must be provided when data does not contain augmented_int or augmented_num" )
-}
-
-.polish_check_columns = function( data, columns ) {
-  missing_columns = setdiff( columns, names( data ) )
-  if ( length( missing_columns ) ) {
-    stop(
-      paste0(
-        "the following columns are not present in data: ",
-        paste( missing_columns, collapse = ", " )
-      )
-    )
-  }
-}
-
-.polish_pattern_values = function( data, pattern, verbosity ) {
-  values = sort( unique( data[[ pattern ]] ) )
-  if ( !length( values ) %in% 2:3 ) {
-    stop( "pattern must have 2 or 3 unique values" )
-  }
-  .msmtools_cli_info(
-    verbosity,
-    paste0( "checking ", pattern, " and defining patterns" )
-  )
-  .msmtools_cli_success(
-    verbosity,
-    paste0( "detected ", length( values ), " values in ", pattern )
-  )
-  values
-}
-
 #' Remove observations with different states occurring at the same time
 #'
 #' Remove subjects with transitions to different states occurring at the same
@@ -219,4 +181,63 @@ polish = function( data, data_key, pattern, time = NULL, check_NA = FALSE,
   }
   data.clean[]
   return( data.clean )
+}
+
+#' Resolve the default duplicate-time column for `polish()`
+#'
+#' Selects `augmented_int` when available, falls back to `augmented_num`, and
+#' errors when no default augmented time column exists.
+#'
+#' @keywords internal
+#' @noRd
+.polish_resolve_time = function( data ) {
+  if ( "augmented_int" %in% names( data ) ) {
+    return( "augmented_int" )
+  }
+  if ( "augmented_num" %in% names( data ) ) {
+    return( "augmented_num" )
+  }
+  stop( "time must be provided when data does not contain augmented_int or augmented_num" )
+}
+
+#' Check that required `polish()` columns exist
+#'
+#' Verifies that captured subject, pattern, and time columns are present before
+#' any keying or duplicate-detection work starts.
+#'
+#' @keywords internal
+#' @noRd
+.polish_check_columns = function( data, columns ) {
+  missing_columns = setdiff( columns, names( data ) )
+  if ( length( missing_columns ) ) {
+    stop(
+      paste0(
+        "the following columns are not present in data: ",
+        paste( missing_columns, collapse = ", " )
+      )
+    )
+  }
+}
+
+#' Extract and validate terminal pattern values for `polish()`
+#'
+#' Computes the unique pattern values and requires the same two- or three-value
+#' terminal outcome schema used by `augment()`.
+#'
+#' @keywords internal
+#' @noRd
+.polish_pattern_values = function( data, pattern, verbosity ) {
+  values = sort( unique( data[[ pattern ]] ) )
+  if ( !length( values ) %in% 2:3 ) {
+    stop( "pattern must have 2 or 3 unique values" )
+  }
+  .msmtools_cli_info(
+    verbosity,
+    paste0( "checking ", pattern, " and defining patterns" )
+  )
+  .msmtools_cli_success(
+    verbosity,
+    paste0( "detected ", length( values ), " values in ", pattern )
+  )
+  values
 }

--- a/R/polish.R
+++ b/R/polish.R
@@ -49,7 +49,6 @@ if (getRversion() >= "2.15.1") {
 #' hosp_aug_clean = polish(data = hosp_aug, data_key = subj, pattern = label_3)
 #'
 #' @author Francesco Grossetti <francesco.grossetti@unibocconi.it>.
-#' @importFrom data.table setDT setkey setkeyv rbindlist uniqueN
 #' @export
 
 polish = function(data, data_key, pattern, time = NULL, check_NA = FALSE,
@@ -77,11 +76,11 @@ polish = function(data, data_key, pattern, time = NULL, check_NA = FALSE,
     data = data.table::copy(data)
   }
   if (inherits(data, 'data.frame')) {
-    setDT(data)
+    data.table::setDT(data)
   }
   .msmtools_cli_rule(verbosity, "setting everything up")
 
-  setkey(data, NULL)
+  data.table::setkey(data, NULL)
   cols = as.character(substitute(data_key))
   if (!length(cols)) {
     cols = colnames(data)
@@ -95,7 +94,7 @@ polish = function(data, data_key, pattern, time = NULL, check_NA = FALSE,
     time = as.character(time_arg)
   }
   .polish_check_columns(data, c(cols, pattern, time))
-  setkeyv(data, cols)
+  data.table::setkeyv(data, cols)
 
   if (isTRUE(check_NA)) {
     .msmtools_cli_info(
@@ -114,13 +113,13 @@ polish = function(data, data_key, pattern, time = NULL, check_NA = FALSE,
   }
 
   data[, index := sequence(.N)]
-  n_patients = uniqueN(data[[cols[[1]]]])
+  n_patients = data.table::uniqueN(data[[cols[[1]]]])
   values = .polish_pattern_values(data, pattern, verbosity)
 
   alive = data[get(pattern) == values[1]]
   alive.last = alive[alive[, .I[.N], by = eval(cols)]$V1]
-  setkey(alive.last, index)
-  setkey(alive, index)
+  data.table::setkey(alive.last, index)
+  data.table::setkey(alive, index)
   alive.no.last = alive[!alive.last]
 
   if (length(values) == 2) {
@@ -130,12 +129,12 @@ polish = function(data, data_key, pattern, time = NULL, check_NA = FALSE,
   }
 
   l = list(alive.no.last, dead)
-  data.no.last.event = rbindlist(l)
+  data.no.last.event = data.table::rbindlist(l)
   row.duplicated = duplicated(data.no.last.event,
                               by = c(eval(cols), eval(time)))
   duplicated = data.no.last.event[row.duplicated == TRUE]
-  n_duplicated = uniqueN(duplicated[[cols[[1]]]])
-  setkeyv(duplicated, cols)
+  n_duplicated = data.table::uniqueN(duplicated[[cols[[1]]]])
+  data.table::setkeyv(duplicated, cols)
 
   if (n_duplicated == 0) {
     .msmtools_cli_success(
@@ -151,7 +150,7 @@ polish = function(data, data_key, pattern, time = NULL, check_NA = FALSE,
       )
     )
     data.clean = data[!duplicated]
-    n_patients.to.keep = uniqueN(data.clean[[cols[[1]]]])
+    n_patients.to.keep = data.table::uniqueN(data.clean[[cols[[1]]]])
     .msmtools_cli_success(
       verbosity,
       paste0(

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![lifecycle](https://lifecycle.r-lib.org/articles/figures/lifecycle-stable.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![R-CMD-check](https://github.com/contefranz/msmtools/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/contefranz/msmtools/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/contefranz/msmtools/branch/main/graph/badge.svg?token=wDcJP6mRRY)](https://codecov.io/gh/contefranz/msmtools)
-[![release](https://img.shields.io/badge/dev.%20version-2.1.0-blue)](https://github.com/contefranz/msmtools)
+[![release](https://img.shields.io/badge/dev.%20version-2.1.1-blue)](https://github.com/contefranz/msmtools)
 [![CRAN Status Badge](https://www.r-pkg.org/badges/version/msmtools)](https://cran.r-project.org/package=msmtools)
 [![license](https://img.shields.io/badge/license-GPL--3-blue.svg)](https://en.wikipedia.org/wiki/GNU_General_Public_License)
 
@@ -73,6 +73,10 @@ unchanged.
 
 
 #### Duplicate Transition Cleanup
+
+`polish()` uses `augmented_int` as the duplicate-time column by default. Set
+`time = NULL` for the same auto-detection behavior, or pass another time column
+explicitly.
 
 ```r
 hosp_clean <- polish(

--- a/man/polish.Rd
+++ b/man/polish.Rd
@@ -8,7 +8,7 @@ polish(
   data,
   data_key,
   pattern,
-  time,
+  time = NULL,
   check_NA = FALSE,
   copy = FALSE,
   verbosity = getOption("msmtools.verbosity", "quiet")
@@ -31,7 +31,9 @@ When 3 values are detected, they must be: 0 = "alive",
 (see Details).}
 
 \item{time}{The time variable used to identify duplicate transition times.
-By default it is set to \code{"augmented_int"}.}
+If omitted or set to \code{NULL}, \code{polish()} uses \code{"augmented_int"} when it is
+available, then \code{"augmented_num"}. If neither column exists, \code{time} must be
+supplied explicitly.}
 
 \item{check_NA}{If \code{TRUE}, \code{data_key}, \code{pattern}, and \code{time} are checked for
 missing values. If any missing values are found, the function stops with an

--- a/man/polish.Rd
+++ b/man/polish.Rd
@@ -70,15 +70,15 @@ result if a plain \code{data.frame} is needed by downstream code.
 \examples{
 
 # loading data
-data( hosp )
+data(hosp)
 
 # augmenting longitudinal data
-hosp_aug = augment( data = hosp, data_key = subj, n_events = adm_number,
-                    pattern = label_3, t_start = dateIN, t_end = dateOUT,
-                    t_cens = dateCENS )
+hosp_aug = augment(data = hosp, data_key = subj, n_events = adm_number,
+                   pattern = label_3, t_start = dateIN, t_end = dateOUT,
+                   t_cens = dateCENS)
 
 # cleaning targeted duplicate transitions
-hosp_aug_clean = polish( data = hosp_aug, data_key = subj, pattern = label_3 )
+hosp_aug_clean = polish(data = hosp_aug, data_key = subj, pattern = label_3)
 
 }
 \seealso{

--- a/tests/testthat/test-polish.R
+++ b/tests/testthat/test-polish.R
@@ -111,9 +111,13 @@ test_that( "polish reports checked missing values clearly", {
 
 test_that( "polish accepts summary verbosity", {
   hosp_aug = augment_hosp()
-  hosp_clean = polish(
-    data.table::copy( hosp_aug ), subj, label_3, verbosity = "summary"
+  output = utils::capture.output(
+    hosp_clean <- polish(
+      data.table::copy( hosp_aug ), subj, label_3, verbosity = "summary"
+    ),
+    type = "message"
   )
 
+  expect_true( length( output ) > 0L )
   expect_s3_class( hosp_clean, "data.table" )
 } )

--- a/tests/testthat/test-polish.R
+++ b/tests/testthat/test-polish.R
@@ -27,6 +27,27 @@ test_that( "polish returns a data.table", {
   expect_s3_class( as.data.frame( hosp_clean ), "data.frame" )
 } )
 
+test_that( "polish resolves time columns explicitly", {
+  hosp_aug = augment_hosp()
+
+  expect_identical(
+    polish( data.table::copy( hosp_aug ), subj, label_3 ),
+    polish( data.table::copy( hosp_aug ), subj, label_3, time = NULL )
+  )
+  expect_identical(
+    polish( data.table::copy( hosp_aug ), subj, label_3 ),
+    polish( data.table::copy( hosp_aug ), subj, label_3, time = augmented_int )
+  )
+
+  fallback_input = data.table::copy( hosp_aug )
+  fallback_input[ , augmented_num := augmented_int ]
+  fallback_input[ , augmented_int := NULL ]
+  fallback = polish( fallback_input, subj, label_3 )
+
+  expect_s3_class( fallback, "data.table" )
+  expect_true( "augmented_num" %in% names( fallback ) )
+} )
+
 test_that( "polish validates logical flags", {
   hosp_aug = augment_hosp()
 
@@ -38,4 +59,61 @@ test_that( "polish validates logical flags", {
     polish( data.table::copy( hosp_aug ), subj, label_3, check_NA = NA ),
     "check_NA must be either TRUE or FALSE"
   )
+} )
+
+test_that( "polish validates columns and pattern schemas", {
+  hosp_aug = augment_hosp()
+
+  no_time = data.table::copy( hosp_aug )
+  no_time[ , augmented_int := NULL ]
+  expect_error(
+    polish( no_time, subj, label_3 ),
+    "time must be provided"
+  )
+  expect_error(
+    polish( data.table::copy( hosp_aug ), missing_subject, label_3 ),
+    "not present in data: missing_subject"
+  )
+  expect_error(
+    polish( data.table::copy( hosp_aug ), subj, missing_pattern ),
+    "not present in data: missing_pattern"
+  )
+  expect_error(
+    polish( data.table::copy( hosp_aug ), subj, label_3, time = missing_time ),
+    "not present in data: missing_time"
+  )
+
+  one_value = data.table::copy( hosp_aug )
+  one_value[ , one_pattern := "alive" ]
+  expect_error(
+    polish( one_value, subj, one_pattern ),
+    "pattern must have 2 or 3 unique values"
+  )
+
+  four_values = data.table::copy( hosp_aug )
+  four_values[ , four_pattern := rep( c( "a", "b", "c", "d" ), length.out = .N ) ]
+  expect_error(
+    polish( four_values, subj, four_pattern ),
+    "pattern must have 2 or 3 unique values"
+  )
+} )
+
+test_that( "polish reports checked missing values clearly", {
+  hosp_aug = augment_hosp()
+  missing_time = data.table::copy( hosp_aug )
+  missing_time[ 1L, augmented_int := NA_real_ ]
+
+  expect_error(
+    polish( missing_time, subj, label_3, check_NA = TRUE ),
+    "missing values detected in: augmented_int"
+  )
+} )
+
+test_that( "polish accepts summary verbosity", {
+  hosp_aug = augment_hosp()
+  hosp_clean = polish(
+    data.table::copy( hosp_aug ), subj, label_3, verbosity = "summary"
+  )
+
+  expect_s3_class( hosp_clean, "data.table" )
 } )


### PR DESCRIPTION
This PR prepares `msmtools` `v2.1.1` with a focused cleanup of `polish()`.

## Changes

- Makes `polish()` time-column handling explicit:
  - omitted `time` or `time = NULL` auto-detects `augmented_int`, then `augmented_num`
  - calls now error clearly when neither default time column exists
- Replaces remaining `polish()` console output with the shared `cli` verbosity helpers.
- Adds clearer validation for missing columns, invalid pattern schemas, and checked missing values.
- Moves private `polish()` helpers below the exported function and documents them as internal.
- Normalizes `R/polish.R` syntax style.
- Qualifies external `data.table` calls with `data.table::` instead of relying on roxygen imports.
- Updates `NEWS.md`, README, and generated `polish()` documentation.

## Validation

- `devtools::test()` passed: 115 passed, 0 failed.
- `R CMD build` passed.
- `R CMD check --no-manual --as-cran` passed with 0 ERROR and 0 WARNING.