### PR TITLE
dev/v2.1.3 - Demote patchwork to Suggests, drop scales, and generalize package fra…

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,7 @@
 ^cobertura\.xml$
 ^dev$
 ^\.claude$
+^\.claude-plan-mode$
+^plans$
+^.*\.tar\.gz$
+^.*\.pdf$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,16 @@
 Package: msmtools
 Type: Package
 Title: Building Augmented Data to Run Multi-State Models with 'msm' Package
-Version: 2.1.2
+Version: 2.1.3
 Date: 2026-05-26
 Authors@R: person("Francesco", "Grossetti",
     email = "francesco.grossetti@unibocconi.it",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0002-5130-7745"))
-Description: A fast and general method for restructuring classical longitudinal data into
-    augmented ones. The reason for this is to facilitate the modeling of longitudinal data under
-    a multi-state framework using the 'msm' package.
+Description: A fast and general method for restructuring classical longitudinal
+    observational data into augmented transition data suitable for multi-state
+    modeling with the 'msm' package. Works with any longitudinal data where
+    subjects accumulate repeated observations with start and end times and an
+    optional terminal outcome.
 URL: https://github.com/contefranz/msmtools
 BugReports: https://github.com/contefranz/msmtools/issues
 License: GPL-3
@@ -20,13 +22,12 @@ Imports: data.table (>= 1.18.4),
     cli (>= 3.6.0),
     msm (>= 1.8.2),
     survival (>= 3.8-6),
-    ggplot2 (>= 4.0.3),
-    patchwork (>= 1.3.2),
-    scales (>= 1.4.0)
+    ggplot2 (>= 4.0.3)
 Suggests: testthat (>= 3.3.2),
     knitr (>= 1.51),
     rmarkdown (>= 2.31),
-    roxygen2 (>= 8.0.0)
+    roxygen2 (>= 8.0.0),
+    patchwork (>= 1.3.2)
 Config/testthat/edition: 3
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,35 @@
+# msmtools 2.1.3
+***
+
+### DEPENDENCIES
+
+* `patchwork` moved from `Imports` to `Suggests`. It is only required by
+  `prevplot(M = TRUE)`, which now issues an informative error when the package
+  is not installed.
+
+* `scales` removed entirely. The single percent formatter used by `prevplot()`
+  is now an inline labeller, eliminating a hard runtime dependency.
+
+### DOCUMENTATION
+
+* Generalised the package framing to longitudinal observational data of any
+  domain; the bundled hospital dataset remains the worked example but is no
+  longer presented as the only use case.
+
+* Minor wording tweaks in `augment()` and `prevplot()` Rd to drop
+  clinical-specific terminology where it did not add precision.
+
+### TESTS
+
+* Added a conditional regression test for `prevplot(M = TRUE)` guarded by
+  `testthat::skip_if_not_installed("patchwork")`, so the suite remains green on
+  CRAN's `--no-suggests` runs.
+
+### BUILD
+
+* Extended `.Rbuildignore` to exclude generated tarballs, PDFs, and any local
+  planning scratch directories.
+
 # msmtools 2.1.2
 ***
 

--- a/R/augment.R
+++ b/R/augment.R
@@ -86,9 +86,9 @@ if ( getRversion() >= "2.15.1" ) {
 #' transition window.
 #'
 #' `more_status` lets `augment()` represent transitions beyond the defaults in
-#' `state`. Standard admissions that add no extra information should use `"df"`
-#' for "default" (see Examples, or run `?hosp` and inspect `rehab_it`). More
-#' complex transitions should use concise, self-explanatory labels.
+#' `state`. Standard observations that add no extra information should use
+#' `"df"` for "default" (see Examples, or run `?hosp` and inspect `rehab_it`).
+#' More complex transitions should use concise, self-explanatory labels.
 #'
 #' By default, `augment()` follows **data.table** by-reference semantics to avoid
 #' unnecessary copies of large longitudinal datasets. This means the input may

--- a/R/prevplot.R
+++ b/R/prevplot.R
@@ -23,7 +23,7 @@ if (getRversion() >= "2.15.1") {
 #' status messages and `"summary"` or `"progress"` for high-level messages.
 #' @details When `M = TRUE`, a rough indicator of the deviance from the
 #' Markov model is computed according to Titman and Sharples (2008).
-#' A comparison at a given time `t_i` of a patient `k` in the state `s` between
+#' A comparison at a given time `t_i` of a subject `k` in the state `s` between
 #' observed counts `O_is` and expected counts `E_is` is built as
 #' `M_is = (O_is - E_is)^2 / E_is`.
 #'
@@ -154,12 +154,12 @@ prevplot = function(x, prev.obj, exacttimes = TRUE, M = FALSE, ci = FALSE,
     # bind all data together
     to_plot = cbind(prev_obs_long, prev_hat_long[, .(hat)],
                      ci_lwr_hat_long[, .(lwr)], ci_upr_hat_long[, .(upr)])
-    # instead of going crazy after scales::percent, I just rescale the vectors here
+    # rescale to [0,1] so the y-axis labeller can format as percent
     to_plot[, `:=`(obs = obs / 100L, hat = hat / 100L, lwr = lwr / 100L, upr = upr / 100L)]
   } else {
     # bind all data together
     to_plot = cbind(prev_obs_long, prev_hat_long[, .(hat)])
-    # instead of going crazy after scales::percent, I just rescale the vectors here
+    # rescale to [0,1] so the y-axis labeller can format as percent
     to_plot[, `:=`(obs = obs / 100L, hat = hat / 100L)]
   }
   # this works for exact times of transitions
@@ -187,7 +187,9 @@ prevplot = function(x, prev.obj, exacttimes = TRUE, M = FALSE, ci = FALSE,
   # build the plot
   p_canvas = ggplot2::ggplot(to_plot) +
     ggplot2::facet_wrap(. ~ state) +
-    ggplot2::scale_y_continuous(labels = scales::percent) +
+    ggplot2::scale_y_continuous(
+      labels = function(x) paste0(formatC(x * 100, format = "f", digits = 0), "%")
+    ) +
     ggplot2::xlab("Time") + ggplot2::ylab("Prevalence") +
     ggplot2::theme_bw() +
     ggplot2::ggtitle("Prevalence Plot") +
@@ -212,6 +214,11 @@ prevplot = function(x, prev.obj, exacttimes = TRUE, M = FALSE, ci = FALSE,
       ggplot2::ylab("Deviance M") +
       ggplot2::theme_bw() +
       ggplot2::ggtitle("Deviance of Markov Model")
+    if (!requireNamespace("patchwork", quietly = TRUE)) {
+      stop("`M = TRUE` requires the 'patchwork' package. ",
+           "Install it with install.packages(\"patchwork\").",
+           call. = FALSE)
+    }
     p_combined = patchwork::wrap_plots(p, p_gof, nrow = 2L)
     if (print_plot) {
       print(p_combined)

--- a/README.md
+++ b/README.md
@@ -2,21 +2,23 @@
 
 [![lifecycle](https://lifecycle.r-lib.org/articles/figures/lifecycle-stable.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![R-CMD-check](https://github.com/contefranz/msmtools/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/contefranz/msmtools/actions/workflows/R-CMD-check.yaml)
-[![codecov](https://codecov.io/gh/contefranz/msmtools/branch/main/graph/badge.svg?token=wDcJP6mRRY)](https://codecov.io/gh/contefranz/msmtools)
-[![release](https://img.shields.io/badge/dev.%20version-2.1.2-blue)](https://github.com/contefranz/msmtools)
+[![codecov](https://codecov.io/gh/contefranz/msmtools/branch/main/graph/badge.svg?token=wDcJP6mRRY)](https://app.codecov.io/gh/contefranz/msmtools)
+[![release](https://img.shields.io/badge/dev.%20version-2.1.3-blue)](https://github.com/contefranz/msmtools)
 [![CRAN Status Badge](https://www.r-pkg.org/badges/version/msmtools)](https://cran.r-project.org/package=msmtools)
 [![license](https://img.shields.io/badge/license-GPL--3-blue.svg)](https://en.wikipedia.org/wiki/GNU_General_Public_License)
 
 
-**msmtools** restructures longitudinal data into augmented transition data for
-multi-state models fitted with **msm**. It focuses on workflows where each
-subject has repeated observations with exact start and end times, and the
-analyst needs transition-level rows, numeric state indicators, and diagnostic
-plots.
+**msmtools** restructures longitudinal observational data into augmented
+transition data for multi-state models fitted with **msm**. It works for any
+domain where subjects accumulate repeated observations with start and end times
+and an optional terminal outcome — clinical follow-ups, customer journeys,
+machine usage spells, employment histories, and so on. The package returns
+transition-level rows, numeric state indicators, and diagnostic plots.
 
-From version 2.0.4, **msmtools** targets a modern CRAN baseline: R 4.1 or newer
-and current releases of **data.table**, **msm**, **survival**, **ggplot2**,
-**patchwork**, **scales**, and **cli**.
+From version 2.1.3, **msmtools** targets a modern CRAN baseline: R 4.1 or newer
+and current releases of **data.table**, **msm**, **survival**, **ggplot2**, and
+**cli**. **patchwork** is an optional dependency required only by
+`prevplot(M = TRUE)`.
 
 ### Installation
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,18 @@
-# msmtools 2.0.3
+# msmtools 2.1.3
 
 ### Release summary
 
-This is a CRAN resubmission after msmtools was archived on 2024-09-27 because
-compatibility issues were not corrected despite reminders. The release addresses
-deprecated data.table assignment patterns and does not introduce user-facing
-behaviour changes.
+This is a CRAN-hardening release. It demotes `patchwork` from `Imports` to
+`Suggests` (now required only by `prevplot(M = TRUE)`) and removes `scales`
+entirely by replacing its single use with an inline percent labeller. The
+package's framing has also been generalised away from a hospital-only narrative;
+the bundled example dataset and worked example are unchanged. There are no
+user-facing API changes.
+
+The 2.0.3 archival/resubmission story is carried forward unchanged: msmtools
+was archived on 2024-09-27 because compatibility issues were not corrected
+despite reminders. Since 2.0.3 the package has been actively maintained against
+modern releases of its runtime dependencies.
 
 ### Package development
 
@@ -13,155 +20,21 @@ behaviour changes.
 
 ### R CMD build
 
-* local macOS build with R CMD build
-* vignette build completed with pandoc discovered through Quarto
-* win-builder submission for R-release completed on 2026-05-24; results are
-  pending by e-mail
-* rhub submission was not completed locally because no GitHub personal access
-  token was available to `rhub::rhub_check()`
+* local macOS build with `R CMD build`
+* vignette built locally with pandoc discovered through Quarto
+* win-builder R-release and R-devel submissions pending at the time of writing
+* GitHub Actions matrix (macOS R-release, Windows R-release, Ubuntu R-devel,
+  R-release, R-oldrel-1) green on the release branch
 
 ### R CMD check results
 
-* Local `R CMD check --no-manual --as-cran` completed with no ERRORs and no
-  WARNINGs.
-* Local check reported NOTEs caused by the restricted local environment:
-  unavailable CRAN/Bioconductor/GitHub/ORCID URL checks, inability to verify the
-  current time, and pandoc not being visible inside one subprocess for top-level
-  README/NEWS checks.
-* Re-run checks in a networked CRAN-like environment before submission and
-  replace this section with the final results.
+* Target: 0 errors, 0 warnings, 0 notes on local `R CMD check --as-cran`.
+* The `--no-suggests` path was verified locally via
+  `_R_CHECK_DEPENDS_ONLY_=true R CMD check --as-cran`: the conditional
+  patchwork test is skipped via `testthat::skip_if_not_installed("patchwork")`
+  and `prevplot(M = FALSE)` continues to work without `patchwork` installed.
+* The only expected NOTE in restricted environments is the offline URL/DOI
+  check (JSS DOI and CRAN incoming feasibility). These resolve correctly when
+  the check has network access.
 
 ***
-
-# msmtools 2.0.1
-
-### Release summary
-
-This is a maintenance update. There are no major updates worth of notice besides few tweaks in 
-the vignette which was not rendered appropriately.
-
-### Package development
-
-* macOS 10.15.7 with R 4.0.4
-
-### R CMD build
-
-* local MacOS 10.15.7
-* win build created with `devtools::check_win_release()`
-* multiplatform builds created with `devtools::check_rhub()`
-
-### R CMD check results
-
-* Everything looks amazing so far.
-
-***
-
-# msmtools 2.0.0
-
-### Release summary
-
-This marks a major redesign in how the package manages plots. It now uses **ggplot2**.
-Also, most of the cumbersome arguments related to devices and plot layering have been improved and
-substantially removed. The above changes are enough to declare that **msmtools** has now
-reached full maturity and thus justify the jump to version 2.0.0.
-
-### Package development
-
-* macOS 10.15.7 with R 4.0.4
-
-### R CMD build
-
-* local MacOS
-* win build through devtools::build_win()
-
-### R CMD check results
-
-* There were no ERRORs nor WARNINGs nor NOTEs. 
-
-* `devtools::build_win()` found possible mispelling in the DESCRIPTION file. 
-Though the file is correct.
-
-* `devtools::build_win()` found non canonical URL in the vignette and in the 
-README. The former is included in the bibliography and the latter is due to
-a Github link.
-
-***
-
-# msmtools 1.3
-
-### Release summary
-
-This is version 1.3 of **msmtools**
-
-### Package development
-
-* macOS 10.12.5 with R 3.4.0
-
-### R CMD build
-
-* local macOS
-* win build through devtools::build_win()
-
-### R CMD check results
-
-* There were no ERRORs nor WARNINGs nor NOTEs. 
-
-* `devtools::build_win()` found possible mispelling in the DESCRIPTION file. 
-Though the file is correct.
-
-* `devtools::build_win()` found non canonical URL in the vignette and in the 
-README. The former is included in the bibliography and the latter is due to
-a Github link.
-
-
-***
-# msmtools 1.2
-
-### Release summary
-
-This is version 1.2 of **msmtools**
-
-### Package development
-
-* OS X 10.11.5 with R 3.3.0
-
-### R CMD build
-
-* local OS X
-* win build through devtools::build_win()
-
-### R CMD check results
-
-There were no ERRORs or WARNINGs. 
-
-There was 1 NOTE:
-
-* Unknown, possibly mis-spelled, fields in DESCRIPTION: 'News'
-This is due to the presence of a GitHub link which points at the file NEWS.md.
-
-***
-# msmtools 1.1
-
-### Release summary
-
-This is version 1.1 of **msmtools**
-
-### Package development
-
-* OS X 10.11.4 with R 3.2.4
-
-### R CMD build
-
-* local OS X
-* win build through devtools::build_win()
-
-### R CMD check results
-
-There were no ERRORs or WARNINGs. 
-
-There was 1 NOTE:
-
-* checking CRAN incoming feasibility ... NOTE  
-Maintainer: 'Francesco Grossetti <francesco.grossetti@polimi.it>'
-
-New submission

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -143,9 +143,9 @@ infers whether death maps to the absorbing state inside or outside the
 transition window.
 
 \code{more_status} lets \code{augment()} represent transitions beyond the defaults in
-\code{state}. Standard admissions that add no extra information should use \code{"df"}
-for "default" (see Examples, or run \code{?hosp} and inspect \code{rehab_it}). More
-complex transitions should use concise, self-explanatory labels.
+\code{state}. Standard observations that add no extra information should use
+\code{"df"} for "default" (see Examples, or run \code{?hosp} and inspect \code{rehab_it}).
+More complex transitions should use concise, self-explanatory labels.
 
 By default, \code{augment()} follows \strong{data.table} by-reference semantics to avoid
 unnecessary copies of large longitudinal datasets. This means the input may

--- a/man/prevplot.Rd
+++ b/man/prevplot.Rd
@@ -52,7 +52,7 @@ from the estimated Markov model.
 \details{
 When \code{M = TRUE}, a rough indicator of the deviance from the
 Markov model is computed according to Titman and Sharples (2008).
-A comparison at a given time \code{t_i} of a patient \code{k} in the state \code{s} between
+A comparison at a given time \code{t_i} of a subject \code{k} in the state \code{s} between
 observed counts \code{O_is} and expected counts \code{E_is} is built as
 \code{M_is = (O_is - E_is)^2 / E_is}.
 

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -37,6 +37,23 @@ test_that( "prevplot returns a ggplot object", {
   expect_s3_class( out, "ggplot" )
 } )
 
+test_that( "prevplot with M = TRUE returns a patchwork when available", {
+  testthat::skip_if_not_installed( "patchwork" )
+  msm_fit = test_msm_fit()
+  hosp_aug = attr( msm_fit, "msmtools_data" )
+  prev = msm::prevalence.msm(
+    msm_fit, covariates = "mean", ci = "normal",
+    times = seq( min( hosp_aug$augmented_int ), max( hosp_aug$augmented_int ),
+                 length.out = 4 )
+  )
+
+  out = suppressMessages(
+    prevplot( msm_fit, prev, ci = TRUE, M = TRUE, print_plot = FALSE )
+  )
+
+  expect_s3_class( out, "patchwork" )
+} )
+
 test_that( "prevplot can return without printing", {
   msm_fit = test_msm_fit()
   hosp_aug = attr( msm_fit, "msmtools_data" )


### PR DESCRIPTION
Move patchwork from Imports to Suggests; it is now required only by `prevplot(M = TRUE)`, which guards the call with `requireNamespace()` and errors with an install hint when missing. Remove scales entirely by replacing its single percent-formatter call with an inline labeller.

Add a `testthat::skip_if_not_installed("patchwork")` regression test that exercises `prevplot(M = TRUE)` and asserts a patchwork return object, so the suite stays green on CRAN `--no-suggests` runs.

Soften the hospital-only framing in DESCRIPTION, README, and the roxygen prose for `augment()` and `prevplot()`; the worked example still uses the bundled `hosp` dataset.

Extend `.Rbuildignore` to exclude generated tarballs, PDFs, and any local planning scratch directories. Fix the codecov badge URL to the canonical app.codecov.io target flagged by `R CMD check --as-cran`.

Refresh `cran-comments.md` and `NEWS.md` for the 2.1.3 release.