### PR TITLE
Post-merge audit: paren style + 2.1.3 polish

### DIFF
--- a/R/augment-helpers.R
+++ b/R/augment-helpers.R
@@ -1,207 +1,207 @@
-.augment_validate_inputs = function( data, state, missing_data, missing_data_key,
+.augment_validate_inputs = function(data, state, missing_data, missing_data_key,
                                      missing_pattern, missing_t_start,
-                                     missing_t_end, missing_t_cens ) {
-  if ( missing_data ) {
-    stop( "a dataset of class data.table or data.frame must be provided" )
+                                     missing_t_end, missing_t_cens) {
+  if (missing_data) {
+    stop("a dataset of class data.table or data.frame must be provided")
   }
-  if ( !inherits( data, "data.table" ) && !inherits( data, "data.frame" ) ) {
-    stop( "a dataset of class data.table or data.frame must be provided" )
+  if (!inherits(data, "data.table") && !inherits(data, "data.frame")) {
+    stop("a dataset of class data.table or data.frame must be provided")
   }
-  if ( missing_data_key ) {
-    stop( "a variable of keying must be provided" )
+  if (missing_data_key) {
+    stop("a variable of keying must be provided")
   }
-  if ( missing_pattern ) {
-    stop( "a pattern must be provided" )
+  if (missing_pattern) {
+    stop("a pattern must be provided")
   }
-  if ( !is.character( state ) || length( state ) != 3 ||
-       anyNA( state ) || any( !nzchar( state ) ) || anyDuplicated( state ) ) {
-    stop( "state must be a character vector of 3 unique non-missing non-empty labels" )
+  if (!is.character(state) || length(state) != 3 ||
+       anyNA(state) || any(!nzchar(state)) || anyDuplicated(state)) {
+    stop("state must be a character vector of 3 unique non-missing non-empty labels")
   }
-  if ( missing_t_start || missing_t_end ) {
-    stop( "a starting and an ending event times must be provided" )
+  if (missing_t_start || missing_t_end) {
+    stop("a starting and an ending event times must be provided")
   }
-  if ( missing_t_cens ) {
-    stop( "a censoring time must be provided" )
-  }
-}
-
-.augment_check_time_classes = function( data, t_start, t_end, t_cens, t_death ) {
-  if ( !identical( class( data[[ t_start ]] ), class( data[[ t_end ]] ) ) ) {
-    stop( "the starting and the ending event times must be of the same class" )
-  }
-  if ( !identical( class( data[[ t_start ]] ), class( data[[ t_cens ]] ) ) ) {
-    stop( "the starting and the censoring event times must be of the same class" )
-  }
-  if ( !is.null( t_death ) &&
-       !identical( class( data[[ t_cens ]] ), class( data[[ t_death ]] ) ) ) {
-    stop( "the censoring and the death event times must be of the same class" )
+  if (missing_t_cens) {
+    stop("a censoring time must be provided")
   }
 }
 
-.augment_prepare_events = function( data, data_key, n_events, t_start,
-                                    verbosity ) {
-  setkey( data, NULL )
-  if ( !is.null( n_events ) ) {
-    cols = c( data_key, n_events )
-    if ( length( n_events ) != 1L || !n_events %in% names( data ) ||
-         !inherits( data[[ n_events ]], "integer" ) ) {
-      stop( "n_events must be an integer" )
+.augment_check_time_classes = function(data, t_start, t_end, t_cens, t_death) {
+  if (!identical(class(data[[ t_start ]]), class(data[[ t_end ]]))) {
+    stop("the starting and the ending event times must be of the same class")
+  }
+  if (!identical(class(data[[ t_start ]]), class(data[[ t_cens ]]))) {
+    stop("the starting and the censoring event times must be of the same class")
+  }
+  if (!is.null(t_death) &&
+       !identical(class(data[[ t_cens ]]), class(data[[ t_death ]]))) {
+    stop("the censoring and the death event times must be of the same class")
+  }
+}
+
+.augment_prepare_events = function(data, data_key, n_events, t_start,
+                                    verbosity) {
+  setkey(data, NULL)
+  if (!is.null(n_events)) {
+    cols = c(data_key, n_events)
+    if (length(n_events) != 1L || !n_events %in% names(data) ||
+         !inherits(data[[ n_events ]], "integer")) {
+      stop("n_events must be an integer")
     }
   } else {
     cols = data_key
-    setkeyv( data, c( data_key, t_start ) )
-    data[ , n_events := seq( .N ), by = eval( data_key ) ]
-    cols = c( cols, "n_events" )
+    setkeyv(data, c(data_key, t_start))
+    data[ , n_events := seq(.N), by = eval(data_key) ]
+    cols = c(cols, "n_events")
   }
 
-  .msmtools_cli_info( verbosity, paste0( "checking monotonicity of ", cols[[ 2 ]] ) )
-  ev = data[ , .( ev = all( get( cols[[ 2 ]] ) == cummax( get( cols[[ 2 ]] ) ) ) ),
-             by = eval( cols[[ 1 ]] ) ]
-  setkeyv( data, c( cols[[ 1 ]], t_start ) )
-  if ( !all( ev$ev ) ) {
-    problem_subjects = ev[ ev == FALSE ][ , get( cols[[ 1 ]] ) ]
+  .msmtools_cli_info(verbosity, paste0("checking monotonicity of ", cols[[ 2 ]]))
+  ev = data[ , .(ev = all(get(cols[[ 2 ]]) == cummax(get(cols[[ 2 ]])))),
+             by = eval(cols[[ 1 ]]) ]
+  setkeyv(data, c(cols[[ 1 ]], t_start))
+  if (!all(ev$ev)) {
+    problem_subjects = ev[ ev == FALSE ][ , get(cols[[ 1 ]]) ]
     .msmtools_cli_info(
       verbosity,
-      paste0( cols[[ 2 ]], " is not monotonic increasing within ", cols[[ 1 ]] )
-    )
+      paste0(cols[[ 2 ]], " is not monotonic increasing within ", cols[[ 1 ]])
+   )
     .msmtools_cli_info(
       verbosity,
-      paste0( "the corresponding subjects are: ",
-              paste( problem_subjects, collapse = "; " ) )
-    )
-    stop( "Please, fix the issues and relaunch augment()" )
+      paste0("the corresponding subjects are: ",
+              paste(problem_subjects, collapse = "; "))
+   )
+    stop("Please, fix the issues and relaunch augment()")
   }
-  .msmtools_cli_success( verbosity, paste0( cols[[ 2 ]], " is monotonic" ) )
-  setkeyv( data, cols )
+  .msmtools_cli_success(verbosity, paste0(cols[[ 2 ]], " is monotonic"))
+  setkeyv(data, cols)
   cols
 }
 
-.augment_check_missing_values = function( data, cols, what ) {
-  missing_cols = cols[ vapply( cols, function( x ) anyNA( data[[ x ]] ),
-                               logical( 1L ) ) ]
-  if ( length( missing_cols ) > 0 ) {
+.augment_check_missing_values = function(data, cols, what) {
+  missing_cols = cols[ vapply(cols, function(x) anyNA(data[[ x ]]),
+                               logical(1L)) ]
+  if (length(missing_cols) > 0) {
     stop(
       "detected missing values in ", what, ": ",
-      paste( missing_cols, collapse = ", " ),
+      paste(missing_cols, collapse = ", "),
       ". Please, fix the issues and relaunch augment()"
-    )
+   )
   }
 }
 
-.augment_pattern_values = function( data, pattern, verbosity ) {
-  values = sort( unique( data[[ pattern ]] ) )
-  .msmtools_cli_info( verbosity, paste0( "checking ", pattern,
-                                         " and defining patterns" ) )
-  if ( length( values ) < 2 ) {
-    stop( paste0( "unit identification label must be an integer, a factor or ",
-                  "a character with at least 2 elements" ) )
+.augment_pattern_values = function(data, pattern, verbosity) {
+  values = sort(unique(data[[ pattern ]]))
+  .msmtools_cli_info(verbosity, paste0("checking ", pattern,
+                                         " and defining patterns"))
+  if (length(values) < 2) {
+    stop(paste0("unit identification label must be an integer, a factor or ",
+                  "a character with at least 2 elements"))
   }
-  if ( length( values ) > 3 ) {
-    stop( "pattern must have 2 or 3 unique values" )
+  if (length(values) > 3) {
+    stop("pattern must have 2 or 3 unique values")
   }
   .msmtools_cli_success(
     verbosity,
-    paste0( "detected ", length( values ), " values in ", pattern )
-  )
+    paste0("detected ", length(values), " values in ", pattern)
+ )
   values
 }
 
-.augment_last_pattern_index = function( data, pattern, data_key, code, value ) {
-  if ( inherits( data[[ pattern ]], c( "integer", "numeric" ) ) ) {
-    data[ get( pattern ) == code, .I[ .N ], by = eval( data_key ) ]$V1
-  } else if ( inherits( data[[ pattern ]], "factor" ) ) {
-    data[ as.integer( get( pattern ) ) - 1 == code,
-          .I[ .N ], by = eval( data_key ) ]$V1
-  } else if ( inherits( data[[ pattern ]], "character" ) ) {
-    data[ get( pattern ) == value, .I[ .N ], by = eval( data_key ) ]$V1
+.augment_last_pattern_index = function(data, pattern, data_key, code, value) {
+  if (inherits(data[[ pattern ]], c("integer", "numeric"))) {
+    data[ get(pattern) == code, .I[ .N ], by = eval(data_key) ]$V1
+  } else if (inherits(data[[ pattern ]], "factor")) {
+    data[ as.integer(get(pattern)) - 1 == code,
+          .I[ .N ], by = eval(data_key) ]$V1
+  } else if (inherits(data[[ pattern ]], "character")) {
+    data[ get(pattern) == value, .I[ .N ], by = eval(data_key) ]$V1
   } else {
-    stop( "pattern must be an integer, a factor or a character" )
+    stop("pattern must be an integer, a factor or a character")
   }
 }
 
-.augment_pattern_matches = function( data, pattern, values, cols, t_end,
-                                     t_cens, t_death ) {
+.augment_pattern_matches = function(data, pattern, values, cols, t_end,
+                                     t_cens, t_death) {
   data_key = cols[[ 1 ]]
-  if ( length( values ) == 2 ) {
+  if (length(values) == 2) {
     match1 = data[
-      .augment_last_pattern_index( data, pattern, data_key, 0, values[ 1 ] )
+      .augment_last_pattern_index(data, pattern, data_key, 0, values[ 1 ])
     ]
     match3 = data[
-      .augment_last_pattern_index( data, pattern, data_key, 1, values[ 2 ] )
+      .augment_last_pattern_index(data, pattern, data_key, 1, values[ 2 ])
     ]
-    death_time = if ( is.null( t_death ) ) t_cens else t_death
-    match3 = match3[ get( t_end ) != get( death_time ) ]
+    death_time = if (is.null(t_death)) t_cens else t_death
+    match3 = match3[ get(t_end) != get(death_time) ]
   } else {
     match1 = data[
-      .augment_last_pattern_index( data, pattern, data_key, 0, values[ 1 ] )
+      .augment_last_pattern_index(data, pattern, data_key, 0, values[ 1 ])
     ]
     match3 = data[
-      .augment_last_pattern_index( data, pattern, data_key, 2, values[ 3 ] )
+      .augment_last_pattern_index(data, pattern, data_key, 2, values[ 3 ])
     ]
   }
-  list( match1 = match1, match3 = match3 )
+  list(match1 = match1, match3 = match3)
 }
 
-.augment_bind_rows = function( data, matches, cols, verbosity ) {
-  .msmtools_cli_info( verbosity, "augmenting data" )
-  final = rbindlist( list( data, data, matches$match1, matches$match3 ) )
-  setkeyv( final, cols )
-  .msmtools_cli_success( verbosity, "data have been augmented" )
+.augment_bind_rows = function(data, matches, cols, verbosity) {
+  .msmtools_cli_info(verbosity, "augmenting data")
+  final = rbindlist(list(data, data, matches$match1, matches$match3))
+  setkeyv(final, cols)
+  .msmtools_cli_success(verbosity, "data have been augmented")
   final
 }
 
-.augment_make_dimensions = function( data, cols, pattern, values, t_end, t_cens,
-                                     t_death, verbosity ) {
-  .msmtools_cli_info( verbosity, "defining dimensions" )
-  if ( length( values ) == 2 ) {
-    if ( is.null( t_death ) ) {
-      t1 = data[ , .( .N,
-                      t_end = max( get( t_end ) ),
-                      t_cens = max( get( t_cens ) ) ), by = eval( cols[[ 1 ]] ) ]
+.augment_make_dimensions = function(data, cols, pattern, values, t_end, t_cens,
+                                     t_death, verbosity) {
+  .msmtools_cli_info(verbosity, "defining dimensions")
+  if (length(values) == 2) {
+    if (is.null(t_death)) {
+      t1 = data[ , .(.N,
+                      t_end = max(get(t_end)),
+                      t_cens = max(get(t_cens))), by = eval(cols[[ 1 ]]) ]
     } else {
-      t1 = data[ , .( .N,
-                      t_end = max( get( t_end ) ),
-                      t_death = max( get( t_death ) ) ), by = eval( cols[[ 1 ]] ) ]
+      t1 = data[ , .(.N,
+                      t_end = max(get(t_end)),
+                      t_death = max(get(t_death))), by = eval(cols[[ 1 ]]) ]
     }
   } else {
-    t1 = data[ , .N, by = eval( cols[[ 1 ]] ) ]
+    t1 = data[ , .N, by = eval(cols[[ 1 ]]) ]
   }
-  setkeyv( t1, cols[[ 1 ]] )
-  t2 = unique( data[ , .( get( cols[[ 1 ]] ), get( pattern ) ) ] )
-  setnames( t2, c( cols[[ 1 ]], "V2" ) )
-  setkeyv( t2, cols[[ 1 ]] )
+  setkeyv(t1, cols[[ 1 ]])
+  t2 = unique(data[ , .(get(cols[[ 1 ]]), get(pattern)) ])
+  setnames(t2, c(cols[[ 1 ]], "V2"))
+  setkeyv(t2, cols[[ 1 ]])
   maker = t1[ t2 ]
-  setkeyv( data, cols[[ 1 ]] )
-  .msmtools_cli_success( verbosity, "dimensions computed" )
+  setkeyv(data, cols[[ 1 ]])
+  .msmtools_cli_success(verbosity, "dimensions computed")
   maker
 }
 
-.augment_status_sequence = function( n, kind, state ) {
-  if ( identical( kind, "alive" ) ) {
-    return( c( rep( c( state[[ 1 ]], state[[ 2 ]] ), n ), state[[ 2 ]] ) )
+.augment_status_sequence = function(n, kind, state) {
+  if (identical(kind, "alive")) {
+    return(c(rep(c(state[[ 1 ]], state[[ 2 ]]), n), state[[ 2 ]]))
   }
-  if ( identical( kind, "dead_in" ) ) {
-    return( c( rep( c( state[[ 1 ]], state[[ 2 ]] ), n - 1L ),
-               state[[ 1 ]], state[[ 3 ]] ) )
+  if (identical(kind, "dead_in")) {
+    return(c(rep(c(state[[ 1 ]], state[[ 2 ]]), n - 1L),
+               state[[ 1 ]], state[[ 3 ]]))
   }
-  c( rep( c( state[[ 1 ]], state[[ 2 ]] ), n ), state[[ 3 ]] )
+  c(rep(c(state[[ 1 ]], state[[ 2 ]]), n), state[[ 3 ]])
 }
 
-.augment_build_status_list = function( n, kind, state, verbosity, name ) {
-  out = vector( mode = "list", length( n ) )
-  progress = .msmtools_cli_progress( verbosity, name, length( n ) )
-  for ( i in seq_along( n ) ) {
-    out[[ i ]] = .augment_status_sequence( n[[ i ]], kind, state )
-    .msmtools_cli_progress_update( progress, i, length( n ) )
+.augment_build_status_list = function(n, kind, state, verbosity, name) {
+  out = vector(mode = "list", length(n))
+  progress = .msmtools_cli_progress(verbosity, name, length(n))
+  for (i in seq_along(n)) {
+    out[[ i ]] = .augment_status_sequence(n[[ i ]], kind, state)
+    .msmtools_cli_progress_update(progress, i, length(n))
   }
-  .msmtools_cli_progress_done( progress )
+  .msmtools_cli_progress_done(progress)
   out
 }
 
-.augment_add_status_two_value = function( final, maker, cols, pattern, values,
-                                          state, t_death, verbosity ) {
+.augment_add_status_two_value = function(final, maker, cols, pattern, values,
+                                          state, t_death, verbosity) {
   a = maker[ V2 == values[ 1 ] ]
-  if ( is.null( t_death ) ) {
+  if (is.null(t_death)) {
     din  = maker[ V2 == values[ 2 ] & t_end == t_cens ]
     dout = maker[ V2 == values[ 2 ] & t_end != t_cens ]
   } else {
@@ -211,185 +211,185 @@
 
   temp1 = din[ , .SD, .SDcols = cols[[ 1 ]] ]
   temp2 = dout[ , .SD, .SDcols = cols[[ 1 ]] ]
-  setkeyv( temp1, cols[[ 1 ]] )
-  setkeyv( temp2, cols[[ 1 ]] )
-  setkeyv( final, cols[[ 1 ]] )
+  setkeyv(temp1, cols[[ 1 ]])
+  setkeyv(temp2, cols[[ 1 ]])
+  setkeyv(final, cols[[ 1 ]])
   din_long  = final[ temp1 ]
   dout_long = final[ temp2 ]
-  a_long = final[ get( pattern ) == values[ 1 ] ]
+  a_long = final[ get(pattern) == values[ 1 ] ]
 
-  .msmtools_cli_info( verbosity, "processing alive units" )
+  .msmtools_cli_info(verbosity, "processing alive units")
   flag_a = unlist(
-    .augment_build_status_list( a$N, "alive", state, verbosity, "alive units" ),
+    .augment_build_status_list(a$N, "alive", state, verbosity, "alive units"),
     recursive = FALSE
-  )
-  .msmtools_cli_info( verbosity, "processing units dead inside a transition" )
+ )
+  .msmtools_cli_info(verbosity, "processing units dead inside a transition")
   flag_din = unlist(
-    .augment_build_status_list( din$N, "dead_in", state, verbosity,
-                                "dead inside transition" ),
+    .augment_build_status_list(din$N, "dead_in", state, verbosity,
+                                "dead inside transition"),
     recursive = FALSE
-  )
-  .msmtools_cli_info( verbosity, "processing units dead outside a transition" )
+ )
+  .msmtools_cli_info(verbosity, "processing units dead outside a transition")
   flag_dout = unlist(
-    .augment_build_status_list( dout$N, "dead_out", state, verbosity,
-                                "dead outside transition" ),
+    .augment_build_status_list(dout$N, "dead_out", state, verbosity,
+                                "dead outside transition"),
     recursive = FALSE
-  )
+ )
 
   a_long[ , status := flag_a ]
   din_long[ , status := flag_din ]
   dout_long[ , status := flag_dout ]
-  final = rbindlist( list( a_long, din_long, dout_long ) )
-  setkeyv( final, cols )
+  final = rbindlist(list(a_long, din_long, dout_long))
+  setkeyv(final, cols)
   final
 }
 
-.augment_add_status_three_value = function( final, maker, values, state,
-                                            verbosity ) {
-  flag_temp = vector( mode = "list", nrow( maker ) )
-  progress = .msmtools_cli_progress( verbosity, "status patterns", nrow( maker ) )
-  for ( i in seq_along( maker$N ) ) {
-    if ( maker$V2[ i ] == values[ 1 ] ) {
-      flag_temp[[ i ]] = .augment_status_sequence( maker$N[ i ], "alive", state )
-    } else if ( maker$V2[ i ] == values[ 2 ] ) {
-      flag_temp[[ i ]] = .augment_status_sequence( maker$N[ i ], "dead_in", state )
-    } else if ( maker$V2[ i ] == values[ 3 ] ) {
-      flag_temp[[ i ]] = .augment_status_sequence( maker$N[ i ], "dead_out", state )
+.augment_add_status_three_value = function(final, maker, values, state,
+                                            verbosity) {
+  flag_temp = vector(mode = "list", nrow(maker))
+  progress = .msmtools_cli_progress(verbosity, "status patterns", nrow(maker))
+  for (i in seq_along(maker$N)) {
+    if (maker$V2[ i ] == values[ 1 ]) {
+      flag_temp[[ i ]] = .augment_status_sequence(maker$N[ i ], "alive", state)
+    } else if (maker$V2[ i ] == values[ 2 ]) {
+      flag_temp[[ i ]] = .augment_status_sequence(maker$N[ i ], "dead_in", state)
+    } else if (maker$V2[ i ] == values[ 3 ]) {
+      flag_temp[[ i ]] = .augment_status_sequence(maker$N[ i ], "dead_out", state)
     }
-    .msmtools_cli_progress_update( progress, i, length( maker$N ) )
+    .msmtools_cli_progress_update(progress, i, length(maker$N))
   }
-  .msmtools_cli_progress_done( progress )
-  final[ , status := unlist( flag_temp, recursive = FALSE ) ]
+  .msmtools_cli_progress_done(progress)
+  final[ , status := unlist(flag_temp, recursive = FALSE) ]
   final
 }
 
-.augment_add_status = function( final, maker, cols, pattern, values, state,
-                                t_death, verbosity ) {
-  .msmtools_cli_info( verbosity, "adding status flag" )
-  if ( length( values ) == 2 ) {
-    final = .augment_add_status_two_value( final, maker, cols, pattern, values,
-                                           state, t_death, verbosity )
+.augment_add_status = function(final, maker, cols, pattern, values, state,
+                                t_death, verbosity) {
+  .msmtools_cli_info(verbosity, "adding status flag")
+  if (length(values) == 2) {
+    final = .augment_add_status_two_value(final, maker, cols, pattern, values,
+                                           state, t_death, verbosity)
   } else {
-    final = .augment_add_status_three_value( final, maker, values, state,
-                                             verbosity )
+    final = .augment_add_status_three_value(final, maker, values, state,
+                                             verbosity)
   }
-  if ( anyNA( final$status ) ) {
-    stop( "status flag has not been built correctly" )
+  if (anyNA(final$status)) {
+    stop("status flag has not been built correctly")
   }
-  .msmtools_cli_success( verbosity, "status flag has been added successfully" )
+  .msmtools_cli_success(verbosity, "status flag has been added successfully")
   final
 }
 
-.augment_add_numeric_status = function( final, status_col, status_num_col,
-                                        verbosity ) {
-  .msmtools_cli_info( verbosity, paste0( "adding numeric ", status_col, " flag" ) )
-  lev = unique( final[[ status_col ]] )
-  for ( i in seq_along( lev ) ) {
-    final[ get( status_col ) == lev[ i ], ( status_num_col ) := i ]
+.augment_add_numeric_status = function(final, status_col, status_num_col,
+                                        verbosity) {
+  .msmtools_cli_info(verbosity, paste0("adding numeric ", status_col, " flag"))
+  lev = unique(final[[ status_col ]])
+  for (i in seq_along(lev)) {
+    final[ get(status_col) == lev[ i ], (status_num_col) := i ]
   }
-  if ( anyNA( final[[ status_num_col ]] ) ) {
-    stop( paste0( "numeric ", status_col, " has not been built correctly" ) )
+  if (anyNA(final[[ status_num_col ]])) {
+    stop(paste0("numeric ", status_col, " has not been built correctly"))
   }
   .msmtools_cli_success(
     verbosity,
-    paste0( "numeric ", status_col, " has been added successfully" )
-  )
+    paste0("numeric ", status_col, " has been added successfully")
+ )
   final
 }
 
-.augment_add_sequential_status = function( final, cols, state, status_col,
-                                           n_status_col, verbosity ) {
-  .msmtools_cli_info( verbosity, paste0( "adding sequential ", status_col, " flag" ) )
-  final[ get( status_col ) != state[[ 3 ]],
-         ( n_status_col ) := paste( get( cols[[ 2 ]] ), " ",
-                                    get( status_col ), sep = "" ) ]
-  final[ get( status_col ) == state[[ 3 ]], ( n_status_col ) := state[[ 3 ]] ]
-  if ( anyNA( final[[ n_status_col ]] ) ) {
-    stop( paste0( "sequential ", status_col, " flag has not been built correctly" ) )
+.augment_add_sequential_status = function(final, cols, state, status_col,
+                                           n_status_col, verbosity) {
+  .msmtools_cli_info(verbosity, paste0("adding sequential ", status_col, " flag"))
+  final[ get(status_col) != state[[ 3 ]],
+         (n_status_col) := paste(get(cols[[ 2 ]]), " ",
+                                    get(status_col), sep = "") ]
+  final[ get(status_col) == state[[ 3 ]], (n_status_col) := state[[ 3 ]] ]
+  if (anyNA(final[[ n_status_col ]])) {
+    stop(paste0("sequential ", status_col, " flag has not been built correctly"))
   }
   .msmtools_cli_success(
     verbosity,
-    paste0( "sequential ", status_col, " flag has been added successfully" )
-  )
+    paste0("sequential ", status_col, " flag has been added successfully")
+ )
   final
 }
 
-.augment_set_time_order = function( final, data, t_start, t_augmented, suffix ) {
-  id_col = which( names( data ) == t_start )
-  before = if ( id_col > 1L ) seq_len( id_col - 1L ) else integer()
-  if ( is.null( suffix ) ) {
-    setcolorder( final, c( before, ncol( final ), id_col:( ncol( final ) - 1L ) ) )
+.augment_set_time_order = function(final, data, t_start, t_augmented, suffix) {
+  id_col = which(names(data) == t_start)
+  before = if (id_col > 1L) seq_len(id_col - 1L) else integer()
+  if (is.null(suffix)) {
+    setcolorder(final, c(before, ncol(final), id_col:(ncol(final) - 1L)))
   } else {
     setcolorder(
       final,
-      c( before, ncol( final ) - 1L, ncol( final ),
-         id_col:( ncol( final ) - 2L ) )
-    )
+      c(before, ncol(final) - 1L, ncol(final),
+         id_col:(ncol(final) - 2L))
+   )
   }
   final
 }
 
-.augment_add_time_columns = function( final, data, state, t_start, t_end,
+.augment_add_time_columns = function(final, data, state, t_start, t_end,
                                       t_cens, t_death, t_augmented,
-                                      verbosity ) {
+                                      verbosity) {
   .msmtools_cli_info(
     verbosity,
-    paste0( "adding variable ", t_augmented, " as new time variable" )
-  )
-  final[ status == state[[ 1 ]], ( t_augmented ) := get( t_start ) ]
-  final[ status == state[[ 2 ]], ( t_augmented ) := get( t_end ) ]
-  death_time = if ( is.null( t_death ) ) t_cens else t_death
-  final[ status == state[[ 3 ]], ( t_augmented ) := get( death_time ) ]
+    paste0("adding variable ", t_augmented, " as new time variable")
+ )
+  final[ status == state[[ 1 ]], (t_augmented) := get(t_start) ]
+  final[ status == state[[ 2 ]], (t_augmented) := get(t_end) ]
+  death_time = if (is.null(t_death)) t_cens else t_death
+  final[ status == state[[ 3 ]], (t_augmented) := get(death_time) ]
 
-  if ( inherits( data[[ t_start ]], "Date" ) ) {
-    int_col = paste0( t_augmented, "_int" )
-    final[ , ( int_col ) := as.integer( get( t_augmented ) ) ]
-    final = .augment_set_time_order( final, data, t_start, t_augmented, "_int" )
+  if (inherits(data[[ t_start ]], "Date")) {
+    int_col = paste0(t_augmented, "_int")
+    final[ , (int_col) := as.integer(get(t_augmented)) ]
+    final = .augment_set_time_order(final, data, t_start, t_augmented, "_int")
     .msmtools_cli_success(
       verbosity,
-      paste0( "variables ", t_augmented, " and ", int_col,
-              " successfully added and repositioned" )
-    )
-  } else if ( inherits( data[[ t_start ]], "difftime" ) ) {
-    num_col = paste0( t_augmented, "_num" )
-    final[ , ( num_col ) := as.numeric( get( t_augmented ) ) ]
-    final = .augment_set_time_order( final, data, t_start, t_augmented, "_num" )
+      paste0("variables ", t_augmented, " and ", int_col,
+              " successfully added and repositioned")
+   )
+  } else if (inherits(data[[ t_start ]], "difftime")) {
+    num_col = paste0(t_augmented, "_num")
+    final[ , (num_col) := as.numeric(get(t_augmented)) ]
+    final = .augment_set_time_order(final, data, t_start, t_augmented, "_num")
     .msmtools_cli_success(
       verbosity,
-      paste0( "variables ", t_augmented, " and ", num_col,
-              " successfully added and repositioned" )
-    )
-  } else if ( inherits( data[[ t_start ]], "integer" ) ||
-              inherits( data[[ t_start ]], "numeric" ) ) {
-    final = .augment_set_time_order( final, data, t_start, t_augmented, NULL )
+      paste0("variables ", t_augmented, " and ", num_col,
+              " successfully added and repositioned")
+   )
+  } else if (inherits(data[[ t_start ]], "integer") ||
+              inherits(data[[ t_start ]], "numeric")) {
+    final = .augment_set_time_order(final, data, t_start, t_augmented, NULL)
     .msmtools_cli_success(
       verbosity,
-      paste0( "variable ", t_augmented, " successfully added and repositioned" )
-    )
+      paste0("variable ", t_augmented, " successfully added and repositioned")
+   )
   }
   final
 }
 
-.augment_add_expanded_status = function( final, data, more_status, cols, state,
-                                         verbosity ) {
+.augment_add_expanded_status = function(final, data, more_status, cols, state,
+                                         verbosity) {
   .msmtools_cli_info(
     verbosity,
-    paste0( "detected a more complex status given by variable ", more_status )
-  )
-  .msmtools_cli_info( verbosity, "adding expanded status flag" )
-  values = unique( data[[ more_status ]] )
+    paste0("detected a more complex status given by variable ", more_status)
+ )
+  .msmtools_cli_info(verbosity, "adding expanded status flag")
+  values = unique(data[[ more_status ]])
   final[ status == state[[ 3 ]], status_exp := state[[ 3 ]] ]
-  for ( i in seq_along( values ) ) {
-    final[ status != state[[ 3 ]] & get( more_status ) == values[ i ],
-           status_exp := paste( values[ i ], "_", status, sep = "" ) ]
+  for (i in seq_along(values)) {
+    final[ status != state[[ 3 ]] & get(more_status) == values[ i ],
+           status_exp := paste(values[ i ], "_", status, sep = "") ]
   }
-  if ( anyNA( final$status_exp ) ) {
-    stop( "expanded status flag has not been built correctly" )
+  if (anyNA(final$status_exp)) {
+    stop("expanded status flag has not been built correctly")
   }
-  .msmtools_cli_success( verbosity, "expanded status flag has been added successfully" )
+  .msmtools_cli_success(verbosity, "expanded status flag has been added successfully")
 
-  final = .augment_add_numeric_status( final, "status_exp", "status_exp_num",
-                                       verbosity )
-  .augment_add_sequential_status( final, cols, state, "status_exp",
-                                  "n_status_exp", verbosity )
+  final = .augment_add_numeric_status(final, "status_exp", "status_exp_num",
+                                       verbosity)
+  .augment_add_sequential_status(final, cols, state, "status_exp",
+                                  "n_status_exp", verbosity)
 }

--- a/R/augment.R
+++ b/R/augment.R
@@ -1,8 +1,8 @@
-if ( getRversion() >= "2.15.1" ) {
-  utils::globalVariables( c( "status", "status_num", "n_status",
+if (getRversion() >= "2.15.1") {
+  utils::globalVariables(c("status", "status_num", "n_status",
                              "status_exp", "status_exp_num", "n_status_exp",
                              ":=", ".", ".I", ".N", ".SD", "N", "V2",
-                             "t_end", "t_cens", "t_death" ) )
+                             "t_end", "t_cens", "t_death"))
 }
 #' Build augmented transition data
 #'
@@ -124,23 +124,23 @@ if ( getRversion() >= "2.15.1" ) {
 #'
 #' @examples
 #' # loading data
-#' data( hosp )
+#' data(hosp)
 #'
 #' # augmenting hosp
-#' hosp_augmented = augment( data = hosp, data_key = subj, n_events = adm_number,
+#' hosp_augmented = augment(data = hosp, data_key = subj, n_events = adm_number,
 #'                           pattern = label_3, t_start = dateIN, t_end = dateOUT,
-#'                           t_cens = dateCENS )
+#'                           t_cens = dateCENS)
 #'
 #' # augmenting hosp by passing more information regarding transitions
 #' # with argument more_status
-#' hosp_augmented_more = augment( data = hosp, data_key = subj, n_events = adm_number,
+#' hosp_augmented_more = augment(data = hosp, data_key = subj, n_events = adm_number,
 #'                                pattern = label_3, t_start = dateIN, t_end = dateOUT,
-#'                                t_cens = dateCENS, more_status = rehab_it )
+#'                                t_cens = dateCENS, more_status = rehab_it)
 #'
 #' # requesting progress output
-#' hosp_augmented = augment( data = hosp, data_key = subj, n_events = adm_number,
+#' hosp_augmented = augment(data = hosp, data_key = subj, n_events = adm_number,
 #'                           pattern = label_3, t_start = dateIN, t_end = dateOUT,
-#'                           t_cens = dateCENS, verbosity = "summary" )
+#'                           t_cens = dateCENS, verbosity = "summary")
 #'
 #' @references Grossetti, F., Ieva, F., and Paganoni, A.M. (2018).
 #' A multi-state approach to patients affected by chronic heart failure.
@@ -160,103 +160,103 @@ if ( getRversion() >= "2.15.1" ) {
 #' @importFrom data.table setDT setkey setkeyv rbindlist uniqueN setcolorder setnames
 #' @export
 
-augment = function( data, data_key, n_events, pattern,
-                    state = c( "IN", "OUT", "DEAD" ),
+augment = function(data, data_key, n_events, pattern,
+                    state = c("IN", "OUT", "DEAD"),
                     t_start, t_end, t_cens, t_death, t_augmented,
                     more_status = NULL, check_NA = FALSE, copy = FALSE,
-                    verbosity = getOption( "msmtools.verbosity", "quiet" ) ) {
+                    verbosity = getOption("msmtools.verbosity", "quiet")) {
 
   tic = proc.time()
-  verbosity = .msmtools_verbosity( verbosity )
-  .msmtools_validate_flag( copy, "copy" )
-  .msmtools_validate_flag( check_NA, "check_NA" )
-  .msmtools_cli_rule( verbosity, "setting everything up" )
+  verbosity = .msmtools_verbosity(verbosity)
+  .msmtools_validate_flag(copy, "copy")
+  .msmtools_validate_flag(check_NA, "check_NA")
+  .msmtools_cli_rule(verbosity, "setting everything up")
 
   .augment_validate_inputs(
     data = data,
     state = state,
-    missing_data = missing( data ),
-    missing_data_key = missing( data_key ),
-    missing_pattern = missing( pattern ),
-    missing_t_start = missing( t_start ),
-    missing_t_end = missing( t_end ),
-    missing_t_cens = missing( t_cens )
-  )
+    missing_data = missing(data),
+    missing_data_key = missing(data_key),
+    missing_pattern = missing(pattern),
+    missing_t_start = missing(t_start),
+    missing_t_end = missing(t_end),
+    missing_t_cens = missing(t_cens)
+ )
 
-  if ( copy ) {
-    data = data.table::copy( data )
+  if (copy) {
+    data = data.table::copy(data)
   }
-  if ( inherits( data, "data.frame" ) ) {
-    setDT( data )
+  if (inherits(data, "data.frame")) {
+    setDT(data)
   }
 
-  data_key = as.character( substitute( data_key ) )
-  pattern = as.character( substitute( pattern ) )
-  t_start = as.character( substitute( t_start ) )
-  t_end = as.character( substitute( t_end ) )
-  t_cens = as.character( substitute( t_cens ) )
-  n_events = if ( missing( n_events ) ) NULL else as.character( substitute( n_events ) )
-  t_death = if ( missing( t_death ) ) NULL else as.character( substitute( t_death ) )
-  t_augmented = if ( missing( t_augmented ) ) {
+  data_key = as.character(substitute(data_key))
+  pattern = as.character(substitute(pattern))
+  t_start = as.character(substitute(t_start))
+  t_end = as.character(substitute(t_end))
+  t_cens = as.character(substitute(t_cens))
+  n_events = if (missing(n_events)) NULL else as.character(substitute(n_events))
+  t_death = if (missing(t_death)) NULL else as.character(substitute(t_death))
+  t_augmented = if (missing(t_augmented)) {
     "augmented"
   } else {
-    as.character( substitute( t_augmented ) )
+    as.character(substitute(t_augmented))
   }
-  more_status_arg = substitute( more_status )
-  more_status = if ( missing( more_status ) || is.null( more_status_arg ) ) {
+  more_status_arg = substitute(more_status)
+  more_status = if (missing(more_status) || is.null(more_status_arg)) {
     NULL
   } else {
-    as.character( more_status_arg )
+    as.character(more_status_arg)
   }
 
-  if ( is.null( t_death ) ) {
-    warning( "no t_death has been passed. Assuming that ", t_cens,
-             " contains both censoring and death times" )
+  if (is.null(t_death)) {
+    warning("no t_death has been passed. Assuming that ", t_cens,
+             " contains both censoring and death times")
   }
 
-  .augment_check_time_classes( data, t_start, t_end, t_cens, t_death )
-  cols = .augment_prepare_events( data, data_key, n_events, t_start, verbosity )
+  .augment_check_time_classes(data, t_start, t_end, t_cens, t_death)
+  cols = .augment_prepare_events(data, data_key, n_events, t_start, verbosity)
 
-  if ( isTRUE( check_NA ) ) {
-    .msmtools_cli_info( verbosity, "checking for missing values" )
+  if (isTRUE(check_NA)) {
+    .msmtools_cli_info(verbosity, "checking for missing values")
     .augment_check_missing_values(
       data,
-      c( cols, pattern, t_start, t_end ),
+      c(cols, pattern, t_start, t_end),
       "function arguments"
-    )
-    .msmtools_cli_success( verbosity, "no missing values detected" )
+   )
+    .msmtools_cli_success(verbosity, "no missing values detected")
   }
 
-  if ( !is.null( more_status ) ) {
-    .augment_check_missing_values( data, more_status, more_status )
+  if (!is.null(more_status)) {
+    .augment_check_missing_values(data, more_status, more_status)
   }
 
-  values = .augment_pattern_values( data, pattern, verbosity )
+  values = .augment_pattern_values(data, pattern, verbosity)
   matches = .augment_pattern_matches(
     data, pattern, values, cols, t_end, t_cens, t_death
-  )
-  final = .augment_bind_rows( data, matches, cols, verbosity )
+ )
+  final = .augment_bind_rows(data, matches, cols, verbosity)
   maker = .augment_make_dimensions(
     data, cols, pattern, values, t_end, t_cens, t_death, verbosity
-  )
+ )
   final = .augment_add_status(
     final, maker, cols, pattern, values, state, t_death, verbosity
-  )
-  final = .augment_add_numeric_status( final, "status", "status_num", verbosity )
+ )
+  final = .augment_add_numeric_status(final, "status", "status_num", verbosity)
   final = .augment_add_sequential_status(
     final, cols, state, "status", "n_status", verbosity
-  )
+ )
   final = .augment_add_time_columns(
     final, data, state, t_start, t_end, t_cens, t_death, t_augmented, verbosity
-  )
-  if ( !is.null( more_status ) ) {
+ )
+  if (!is.null(more_status)) {
     final = .augment_add_expanded_status(
       final, data, more_status, cols, state, verbosity
-    )
+   )
   }
 
   time = proc.time() - tic
-  .msmtools_cli_rule( verbosity, paste0( "augment() took: ", time[ 3 ], " sec." ) )
+  .msmtools_cli_rule(verbosity, paste0("augment() took: ", time[ 3 ], " sec."))
   final[]
-  return( final )
+  return(final)
 }

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -1,9 +1,9 @@
 #' @importFrom utils packageVersion
-.onAttach = function( libname, pkgname ) {
+.onAttach = function(libname, pkgname) {
   # Runs when attached to search() path such as by library() or require()
-  if ( interactive() ) {
-    packageStartupMessage( 'Welcome to msmtools v', as.character( packageVersion( "msmtools" ) ),
-                           '! An easy way to build augmented longitudinal datasets to be used with msm' )
-    packageStartupMessage( 'If you find a bug, please report it at https://github.com/contefranz/msmtools/issues' )
+  if (interactive()) {
+    packageStartupMessage('Welcome to msmtools v', as.character(packageVersion("msmtools")),
+                           '! An easy way to build augmented longitudinal datasets to be used with msm')
+    packageStartupMessage('If you find a bug, please report it at https://github.com/contefranz/msmtools/issues')
   }
 }

--- a/R/preprocess-helpers.R
+++ b/R/preprocess-helpers.R
@@ -1,5 +1,5 @@
-.msmtools_validate_flag = function( x, name ) {
-  if ( !is.logical( x ) || length( x ) != 1L || is.na( x ) ) {
-    stop( name, " must be either TRUE or FALSE" )
+.msmtools_validate_flag = function(x, name) {
+  if (!is.logical(x) || length(x) != 1L || is.na(x)) {
+    stop(name, " must be either TRUE or FALSE")
   }
 }

--- a/R/prevplot.R
+++ b/R/prevplot.R
@@ -29,6 +29,12 @@ if (getRversion() >= "2.15.1") {
 #'
 #' The deviance `M` plot is returned together with the standard prevalence plot
 #' in the second row. This layout is fixed.
+#'
+#' When `M = TRUE`, the combined layout is built with **patchwork**, which is
+#' an optional dependency of **msmtools**. Install it with
+#' `install.packages("patchwork")` if it is not already available; `prevplot()`
+#' raises an informative error otherwise. The default `M = FALSE` path has no
+#' such requirement.
 #' @returns When `M = FALSE`, a `gg/ggplot` object with observed and expected
 #' prevalences is returned. When `M = TRUE`, a `patchwork` object is returned
 #' with the prevalence plot and the deviance `M` plot.
@@ -188,7 +194,7 @@ prevplot = function(x, prev.obj, exacttimes = TRUE, M = FALSE, ci = FALSE,
   p_canvas = ggplot2::ggplot(to_plot) +
     ggplot2::facet_wrap(. ~ state) +
     ggplot2::scale_y_continuous(
-      labels = function(x) paste0(formatC(x * 100, format = "f", digits = 0), "%")
+      labels = function(x) paste0(formatC(x * 100, format = "f", digits = 1), "%")
     ) +
     ggplot2::xlab("Time") + ggplot2::ylab("Prevalence") +
     ggplot2::theme_bw() +

--- a/R/verbosity.R
+++ b/R/verbosity.R
@@ -1,55 +1,55 @@
-.msmtools_verbosity = function( verbosity ) {
-  verbosity = match.arg( verbosity, c( "quiet", "summary", "progress" ) )
+.msmtools_verbosity = function(verbosity) {
+  verbosity = match.arg(verbosity, c("quiet", "summary", "progress"))
   verbosity
 }
 
-.msmtools_is_summary = function( verbosity ) {
-  verbosity %in% c( "summary", "progress" )
+.msmtools_is_summary = function(verbosity) {
+  verbosity %in% c("summary", "progress")
 }
 
-.msmtools_cli_rule = function( verbosity, text ) {
-  if ( .msmtools_is_summary( verbosity ) ) {
-    cli::cli_rule( text )
+.msmtools_cli_rule = function(verbosity, text) {
+  if (.msmtools_is_summary(verbosity)) {
+    cli::cli_rule(text)
   }
 }
 
-.msmtools_cli_info = function( verbosity, text ) {
-  if ( .msmtools_is_summary( verbosity ) ) {
-    cli::cli_alert_info( text )
+.msmtools_cli_info = function(verbosity, text) {
+  if (.msmtools_is_summary(verbosity)) {
+    cli::cli_alert_info(text)
   }
 }
 
-.msmtools_cli_success = function( verbosity, text ) {
-  if ( .msmtools_is_summary( verbosity ) ) {
-    cli::cli_alert_success( text )
+.msmtools_cli_success = function(verbosity, text) {
+  if (.msmtools_is_summary(verbosity)) {
+    cli::cli_alert_success(text)
   }
 }
 
-.msmtools_cli_progress = function( verbosity, name, total ) {
-  if ( identical( verbosity, "progress" ) && total > 0 ) {
+.msmtools_cli_progress = function(verbosity, name, total) {
+  if (identical(verbosity, "progress") && total > 0) {
     return(
       cli::cli_progress_bar(
         name,
         total = total,
         auto_terminate = FALSE,
         .envir = parent.frame()
-      )
-    )
+     )
+   )
   }
   NULL
 }
 
-.msmtools_cli_progress_update = function( id, i, total ) {
-  if ( !is.null( id ) ) {
-    step = max( 1L, floor( total / 100L ) )
-    if ( i == total || i %% step == 0L ) {
-      cli::cli_progress_update( id = id, set = i )
+.msmtools_cli_progress_update = function(id, i, total) {
+  if (!is.null(id)) {
+    step = max(1L, floor(total / 100L))
+    if (i == total || i %% step == 0L) {
+      cli::cli_progress_update(id = id, set = i)
     }
   }
 }
 
-.msmtools_cli_progress_done = function( id ) {
-  if ( !is.null( id ) ) {
-    cli::cli_progress_done( id = id )
+.msmtools_cli_progress_done = function(id) {
+  if (!is.null(id)) {
+    cli::cli_progress_done(id = id)
   }
 }

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ and an optional terminal outcome — clinical follow-ups, customer journeys,
 machine usage spells, employment histories, and so on. The package returns
 transition-level rows, numeric state indicators, and diagnostic plots.
 
-From version 2.1.3, **msmtools** targets a modern CRAN baseline: R 4.1 or newer
+From version 2.0.4, **msmtools** targets a modern CRAN baseline: R 4.1 or newer
 and current releases of **data.table**, **msm**, **survival**, **ggplot2**, and
-**cli**. **patchwork** is an optional dependency required only by
+**cli**. Since 2.1.3, **patchwork** is an optional dependency required only by
 `prevplot(M = TRUE)`.
 
 ### Installation

--- a/dev/benchmarks/baseline-2.0.9.md
+++ b/dev/benchmarks/baseline-2.0.9.md
@@ -3,6 +3,12 @@
 This is a local developer baseline, not a public performance guarantee.
 The script is excluded from package builds and must be run manually.
 
+> **Note**: this baseline was captured against the 2.0.9 dependency set.
+> Since msmtools 2.1.3, `scales` has been removed entirely and `patchwork`
+> demoted to Suggests (required only by `prevplot(M = TRUE)`). The figures
+> below are still meaningful for `augment()` and `polish()`, which are the
+> only functions exercised by this baseline.
+
 - Generated: 2026-05-25 09:51:57 CEST
 - R version: R version 4.5.1 (2025-06-13)
 - Platform: aarch64-apple-darwin24.4.0

--- a/man/augment.Rd
+++ b/man/augment.Rd
@@ -158,23 +158,23 @@ result if a plain \code{data.frame} is needed by downstream code.
 }
 \examples{
 # loading data
-data( hosp )
+data(hosp)
 
 # augmenting hosp
-hosp_augmented = augment( data = hosp, data_key = subj, n_events = adm_number,
+hosp_augmented = augment(data = hosp, data_key = subj, n_events = adm_number,
                           pattern = label_3, t_start = dateIN, t_end = dateOUT,
-                          t_cens = dateCENS )
+                          t_cens = dateCENS)
 
 # augmenting hosp by passing more information regarding transitions
 # with argument more_status
-hosp_augmented_more = augment( data = hosp, data_key = subj, n_events = adm_number,
+hosp_augmented_more = augment(data = hosp, data_key = subj, n_events = adm_number,
                                pattern = label_3, t_start = dateIN, t_end = dateOUT,
-                               t_cens = dateCENS, more_status = rehab_it )
+                               t_cens = dateCENS, more_status = rehab_it)
 
 # requesting progress output
-hosp_augmented = augment( data = hosp, data_key = subj, n_events = adm_number,
+hosp_augmented = augment(data = hosp, data_key = subj, n_events = adm_number,
                           pattern = label_3, t_start = dateIN, t_end = dateOUT,
-                          t_cens = dateCENS, verbosity = "summary" )
+                          t_cens = dateCENS, verbosity = "summary")
 
 }
 \references{

--- a/man/prevplot.Rd
+++ b/man/prevplot.Rd
@@ -58,6 +58,12 @@ observed counts \code{O_is} and expected counts \code{E_is} is built as
 
 The deviance \code{M} plot is returned together with the standard prevalence plot
 in the second row. This layout is fixed.
+
+When \code{M = TRUE}, the combined layout is built with \strong{patchwork}, which is
+an optional dependency of \strong{msmtools}. Install it with
+\code{install.packages("patchwork")} if it is not already available; \code{prevplot()}
+raises an informative error otherwise. The default \code{M = FALSE} path has no
+such requirement.
 }
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}

--- a/tests/testthat/helper-msmtools.R
+++ b/tests/testthat/helper-msmtools.R
@@ -1,42 +1,42 @@
 test_hosp = function() {
-  utils::data( "hosp", package = "msmtools", envir = environment() )
-  data.table::copy( hosp )
+  utils::data("hosp", package = "msmtools", envir = environment())
+  data.table::copy(hosp)
 }
 
-augment_hosp = function( data = test_hosp(), pattern = c( "label_3", "label_2" ),
-                         ... ) {
-  pattern = match.arg( pattern )
-  if ( pattern == "label_3" ) {
+augment_hosp = function(data = test_hosp(), pattern = c("label_3", "label_2"),
+                         ...) {
+  pattern = match.arg(pattern)
+  if (pattern == "label_3") {
     suppressWarnings(
-      augment( data = data, data_key = subj, n_events = adm_number,
+      augment(data = data, data_key = subj, n_events = adm_number,
                pattern = label_3, t_start = dateIN, t_end = dateOUT,
-               t_cens = dateCENS, ... )
-    )
+               t_cens = dateCENS, ...)
+   )
   } else {
     suppressWarnings(
-      augment( data = data, data_key = subj, n_events = adm_number,
+      augment(data = data, data_key = subj, n_events = adm_number,
                pattern = label_2, t_start = dateIN, t_end = dateOUT,
-               t_cens = dateCENS, ... )
-    )
+               t_cens = dateCENS, ...)
+   )
   }
 }
 
 test_qmatrix = function() {
-  qmat = matrix( data = 0, nrow = 3, ncol = 3, byrow = TRUE )
+  qmat = matrix(data = 0, nrow = 3, ncol = 3, byrow = TRUE)
   qmat[ 1, 1:3 ] = 1
   qmat[ 2, 1:3 ] = 1
-  colnames( qmat ) = c( "IN", "OUT", "DEAD" )
-  rownames( qmat ) = c( "IN", "OUT", "DEAD" )
+  colnames(qmat) = c("IN", "OUT", "DEAD")
+  rownames(qmat) = c("IN", "OUT", "DEAD")
   qmat
 }
 
 test_msm_fit = function() {
   hosp_augmented = augment_hosp()
-  fit = msm::msm( status_num ~ augmented_int, subject = subj,
+  fit = msm::msm(status_num ~ augmented_int, subject = subj,
                   data = hosp_augmented, exacttimes = TRUE, gen.inits = TRUE,
                   qmatrix = test_qmatrix(), method = "BFGS",
-                  control = list( fnscale = 6e+05, trace = 0, REPORT = 1,
-                                  maxit = 10000 ) )
-  attr( fit, "msmtools_data" ) = hosp_augmented
+                  control = list(fnscale = 6e+05, trace = 0, REPORT = 1,
+                                  maxit = 10000))
+  attr(fit, "msmtools_data") = hosp_augmented
   fit
 }

--- a/tests/testthat/test-augment.R
+++ b/tests/testthat/test-augment.R
@@ -1,283 +1,283 @@
-test_that( "augment warns when t_cens is used as death time", {
+test_that("augment warns when t_cens is used as death time", {
   expect_warning(
-    augment( test_hosp(), subj, adm_number, label_3, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS ),
+    augment(test_hosp(), subj, adm_number, label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS),
     "no t_death has been passed"
-  )
-} )
+ )
+})
 
-test_that( "n_events must be an integer", {
+test_that("n_events must be an integer", {
   expect_error(
-    augment( test_hosp(), subj, !as.integer( adm_number ), label_3,
+    augment(test_hosp(), subj, !as.integer(adm_number), label_3,
              t_start = dateIN, t_end = dateOUT, t_cens = dateCENS,
-             t_death = dateCENS ),
+             t_death = dateCENS),
     "n_events must be an integer"
-  )
-} )
+ )
+})
 
-test_that( "augment validates required inputs and state shape", {
-  expect_error( augment(), "dataset" )
-  expect_error( augment( data.frame() ), "keying" )
-  expect_error( augment( test_hosp(), subj ), "pattern" )
+test_that("augment validates required inputs and state shape", {
+  expect_error(augment(), "dataset")
+  expect_error(augment(data.frame()), "keying")
+  expect_error(augment(test_hosp(), subj), "pattern")
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3, state = list( "IN" ),
-             t_start = dateIN, t_end = dateOUT, t_cens = dateCENS ),
+    augment(test_hosp(), subj, adm_number, label_3, state = list("IN"),
+             t_start = dateIN, t_end = dateOUT, t_cens = dateCENS),
     "state must be a character vector"
-  )
+ )
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3, t_end = dateOUT,
-             t_cens = dateCENS ),
+    augment(test_hosp(), subj, adm_number, label_3, t_end = dateOUT,
+             t_cens = dateCENS),
     "starting and an ending"
-  )
+ )
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3, t_start = dateIN,
-             t_end = dateOUT ),
+    augment(test_hosp(), subj, adm_number, label_3, t_start = dateIN,
+             t_end = dateOUT),
     "censoring time"
-  )
-} )
+ )
+})
 
-test_that( "augment validates time classes", {
+test_that("augment validates time classes", {
   hosp_bad = test_hosp()
-  hosp_bad[ , dateOUT_num := as.numeric( dateOUT ) ]
+  hosp_bad[ , dateOUT_num := as.numeric(dateOUT) ]
 
   expect_warning(
     expect_error(
-      augment( hosp_bad, subj, adm_number, label_3, t_start = dateIN,
-               t_end = dateOUT_num, t_cens = dateCENS ),
+      augment(hosp_bad, subj, adm_number, label_3, t_start = dateIN,
+               t_end = dateOUT_num, t_cens = dateCENS),
       "same class"
-    ),
+   ),
     "no t_death has been passed"
-  )
+ )
   expect_error(
-    augment( hosp_bad, subj, adm_number, label_3, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS, t_death = dateOUT_num ),
+    augment(hosp_bad, subj, adm_number, label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateOUT_num),
     "same class"
-  )
-} )
+ )
+})
 
-test_that( "two-state and three-state pattern inputs are equivalent", {
-  hosp_aug_2 = augment_hosp( pattern = "label_2" )
-  hosp_aug_3 = augment_hosp( pattern = "label_3" )
+test_that("two-state and three-state pattern inputs are equivalent", {
+  hosp_aug_2 = augment_hosp(pattern = "label_2")
+  hosp_aug_3 = augment_hosp(pattern = "label_3")
 
-  expect_identical( hosp_aug_2, hosp_aug_3 )
-} )
+  expect_identical(hosp_aug_2, hosp_aug_3)
+})
 
-test_that( "missing n_events is reconstructed from subject order", {
+test_that("missing n_events is reconstructed from subject order", {
   hosp_aug = augment_hosp()
   hosp_aug_no_events = suppressWarnings(
-    augment( test_hosp(), subj, pattern = label_3, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS )
-  )
+    augment(test_hosp(), subj, pattern = label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS)
+ )
 
-  expect_identical( hosp_aug$adm_number, hosp_aug_no_events$n_events )
-} )
+  expect_identical(hosp_aug$adm_number, hosp_aug_no_events$n_events)
+})
 
-test_that( "state must be a valid character vector", {
+test_that("state must be a valid character vector", {
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3,
-             state = list( "IN", "OUT", "DEAD" ), t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    augment(test_hosp(), subj, adm_number, label_3,
+             state = list("IN", "OUT", "DEAD"), t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS),
     "state must be a character vector"
-  )
+ )
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3,
-             state = c( "IN", "OUT" ), t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    augment(test_hosp(), subj, adm_number, label_3,
+             state = c("IN", "OUT"), t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS),
     "state must be a character vector"
-  )
+ )
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3,
-             state = c( "IN", NA, "DEAD" ), t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    augment(test_hosp(), subj, adm_number, label_3,
+             state = c("IN", NA, "DEAD"), t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS),
     "state must be a character vector"
-  )
+ )
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3,
-             state = c( "IN", "", "DEAD" ), t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    augment(test_hosp(), subj, adm_number, label_3,
+             state = c("IN", "", "DEAD"), t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS),
     "state must be a character vector"
-  )
+ )
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3,
-             state = c( "IN", "IN", "DEAD" ), t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    augment(test_hosp(), subj, adm_number, label_3,
+             state = c("IN", "IN", "DEAD"), t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS),
     "state must be a character vector"
-  )
-} )
+ )
+})
 
-test_that( "state vector controls generated transition labels", {
-  custom_state = c( "ENTRY", "EXIT", "ABSORBING" )
-  hosp_aug_3 = augment_hosp( state = custom_state, pattern = "label_3" )
-  hosp_aug_2 = augment_hosp( state = custom_state, pattern = "label_2" )
+test_that("state vector controls generated transition labels", {
+  custom_state = c("ENTRY", "EXIT", "ABSORBING")
+  hosp_aug_3 = augment_hosp(state = custom_state, pattern = "label_3")
+  hosp_aug_2 = augment_hosp(state = custom_state, pattern = "label_2")
 
-  expect_true( all( hosp_aug_3$status %in% custom_state ) )
-  expect_true( all( hosp_aug_2$status %in% custom_state ) )
-  expect_true( all( custom_state %in% hosp_aug_3$status ) )
-  expect_true( all( custom_state %in% hosp_aug_2$status ) )
-  expect_true( all( hosp_aug_3$n_status[ hosp_aug_3$status == "ABSORBING" ] ==
-                      "ABSORBING" ) )
-  expect_true( all( hosp_aug_2$n_status[ hosp_aug_2$status == "ABSORBING" ] ==
-                      "ABSORBING" ) )
-} )
+  expect_true(all(hosp_aug_3$status %in% custom_state))
+  expect_true(all(hosp_aug_2$status %in% custom_state))
+  expect_true(all(custom_state %in% hosp_aug_3$status))
+  expect_true(all(custom_state %in% hosp_aug_2$status))
+  expect_true(all(hosp_aug_3$n_status[ hosp_aug_3$status == "ABSORBING" ] ==
+                      "ABSORBING"))
+  expect_true(all(hosp_aug_2$n_status[ hosp_aug_2$status == "ABSORBING" ] ==
+                      "ABSORBING"))
+})
 
-test_that( "check_NA catches missing values and passes clean data", {
+test_that("check_NA catches missing values and passes clean data", {
   expect_warning(
     expect_no_error(
-      augment( test_hosp(), subj, adm_number, label_3, t_start = dateIN,
-               t_end = dateOUT, t_cens = dateCENS, check_NA = TRUE )
-    ),
+      augment(test_hosp(), subj, adm_number, label_3, t_start = dateIN,
+               t_end = dateOUT, t_cens = dateCENS, check_NA = TRUE)
+   ),
     "no t_death has been passed"
-  )
+ )
 
   hosp_missing = test_hosp()
-  hosp_missing[ 1, dateIN := as.Date( NA ) ]
+  hosp_missing[ 1, dateIN := as.Date(NA) ]
 
   expect_warning(
     expect_error(
-      augment( hosp_missing, subj, adm_number, label_3, t_start = dateIN,
-               t_end = dateOUT, t_cens = dateCENS, check_NA = TRUE ),
+      augment(hosp_missing, subj, adm_number, label_3, t_start = dateIN,
+               t_end = dateOUT, t_cens = dateCENS, check_NA = TRUE),
       "dateIN"
-    ),
+   ),
     "no t_death has been passed"
-  )
-} )
+ )
+})
 
-test_that( "augment returns a data.table", {
+test_that("augment returns a data.table", {
   aug_dt = augment_hosp()
 
-  expect_s3_class( aug_dt, "data.table" )
-  expect_s3_class( as.data.frame( aug_dt ), "data.frame" )
-} )
+  expect_s3_class(aug_dt, "data.table")
+  expect_s3_class(as.data.frame(aug_dt), "data.frame")
+})
 
-test_that( "verbosity controls informational output", {
+test_that("verbosity controls informational output", {
   messages = utils::capture.output(
-    aug <- augment( test_hosp(), subj, adm_number, label_3, t_start = dateIN,
+    aug <- augment(test_hosp(), subj, adm_number, label_3, t_start = dateIN,
                     t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS,
-                    verbosity = "summary" ),
+                    verbosity = "summary"),
     type = "message"
-  )
-  expect_s3_class( aug, "data.table" )
-  expect_true( any( grepl( "setting everything up", messages ) ) )
+ )
+  expect_s3_class(aug, "data.table")
+  expect_true(any(grepl("setting everything up", messages)))
 
   progress_messages = utils::capture.output(
-    aug_progress <- augment( test_hosp(), subj, adm_number, label_3,
+    aug_progress <- augment(test_hosp(), subj, adm_number, label_3,
                              t_start = dateIN, t_end = dateOUT,
                              t_cens = dateCENS, t_death = dateCENS,
-                             verbosity = "progress" ),
+                             verbosity = "progress"),
     type = "message"
-  )
-  expect_s3_class( aug_progress, "data.table" )
-  expect_true( any( grepl( "adding status flag", progress_messages ) ) )
+ )
+  expect_s3_class(aug_progress, "data.table")
+  expect_true(any(grepl("adding status flag", progress_messages)))
 
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3, t_start = dateIN,
+    augment(test_hosp(), subj, adm_number, label_3, t_start = dateIN,
              t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS,
-             verbosity = "loud" ),
+             verbosity = "loud"),
     "arg"
-  )
-} )
+ )
+})
 
-test_that( "copy validates logical flags", {
+test_that("copy validates logical flags", {
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3, t_start = dateIN,
+    augment(test_hosp(), subj, adm_number, label_3, t_start = dateIN,
              t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS,
-             copy = "yes" ),
+             copy = "yes"),
     "copy must be either TRUE or FALSE"
-  )
+ )
   expect_error(
-    augment( test_hosp(), subj, adm_number, label_3, t_start = dateIN,
+    augment(test_hosp(), subj, adm_number, label_3, t_start = dateIN,
              t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS,
-             check_NA = NA ),
+             check_NA = NA),
     "check_NA must be either TRUE or FALSE"
-  )
-} )
+ )
+})
 
-test_that( "Date inputs create integer augmented time", {
-  hosp_aug = augment_hosp( t_augmented = event_time )
+test_that("Date inputs create integer augmented time", {
+  hosp_aug = augment_hosp(t_augmented = event_time)
 
-  expect_true( "event_time" %in% names( hosp_aug ) )
-  expect_true( "event_time_int" %in% names( hosp_aug ) )
-  expect_s3_class( hosp_aug$event_time, "Date" )
-  expect_type( hosp_aug$event_time_int, "integer" )
-} )
+  expect_true("event_time" %in% names(hosp_aug))
+  expect_true("event_time_int" %in% names(hosp_aug))
+  expect_s3_class(hosp_aug$event_time, "Date")
+  expect_type(hosp_aug$event_time_int, "integer")
+})
 
-test_that( "numeric time inputs keep numeric augmented time", {
+test_that("numeric time inputs keep numeric augmented time", {
   hosp_num = test_hosp()
-  hosp_num[ , dateIN_num := as.numeric( dateIN ) ]
-  hosp_num[ , dateOUT_num := as.numeric( dateOUT ) ]
-  hosp_num[ , dateCENS_num := as.numeric( dateCENS ) ]
+  hosp_num[ , dateIN_num := as.numeric(dateIN) ]
+  hosp_num[ , dateOUT_num := as.numeric(dateOUT) ]
+  hosp_num[ , dateCENS_num := as.numeric(dateCENS) ]
 
   hosp_aug = suppressWarnings(
-    augment( hosp_num, subj, adm_number, label_3, t_start = dateIN_num,
-             t_end = dateOUT_num, t_cens = dateCENS_num )
-  )
+    augment(hosp_num, subj, adm_number, label_3, t_start = dateIN_num,
+             t_end = dateOUT_num, t_cens = dateCENS_num)
+ )
 
-  expect_true( "augmented" %in% names( hosp_aug ) )
-  expect_false( "augmented_int" %in% names( hosp_aug ) )
-  expect_type( hosp_aug$augmented, "double" )
-} )
+  expect_true("augmented" %in% names(hosp_aug))
+  expect_false("augmented_int" %in% names(hosp_aug))
+  expect_type(hosp_aug$augmented, "double")
+})
 
-test_that( "integer and factor patterns are accepted", {
+test_that("integer and factor patterns are accepted", {
   hosp_int = test_hosp()
   hosp_int[ , label_int := data.table::fifelse(
     label_3 == "alive", 0L,
-    data.table::fifelse( label_3 == "dead_in", 1L, 2L )
-  ) ]
+    data.table::fifelse(label_3 == "dead_in", 1L, 2L)
+ ) ]
   hosp_factor = test_hosp()
-  hosp_factor[ , label_factor := factor( label_3,
-                                         levels = c( "alive", "dead_in", "dead_out" ) ) ]
+  hosp_factor[ , label_factor := factor(label_3,
+                                         levels = c("alive", "dead_in", "dead_out")) ]
 
   int_aug = suppressWarnings(
-    augment( hosp_int, subj, adm_number, label_int, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS )
-  )
+    augment(hosp_int, subj, adm_number, label_int, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS)
+ )
   factor_aug = suppressWarnings(
-    augment( hosp_factor, subj, adm_number, label_factor, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS )
-  )
+    augment(hosp_factor, subj, adm_number, label_factor, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS)
+ )
 
-  expect_equal( nrow( int_aug ), nrow( factor_aug ) )
-  expect_equal( int_aug$status, factor_aug$status )
-} )
+  expect_equal(nrow(int_aug), nrow(factor_aug))
+  expect_equal(int_aug$status, factor_aug$status)
+})
 
-test_that( "difftime inputs create numeric augmented time", {
+test_that("difftime inputs create numeric augmented time", {
   hosp_diff = test_hosp()
-  origin = min( hosp_diff$dateIN )
-  hosp_diff[ , dateIN_diff := as.difftime( as.numeric( dateIN - origin ),
-                                           units = "days" ) ]
-  hosp_diff[ , dateOUT_diff := as.difftime( as.numeric( dateOUT - origin ),
-                                            units = "days" ) ]
-  hosp_diff[ , dateCENS_diff := as.difftime( as.numeric( dateCENS - origin ),
-                                             units = "days" ) ]
+  origin = min(hosp_diff$dateIN)
+  hosp_diff[ , dateIN_diff := as.difftime(as.numeric(dateIN - origin),
+                                           units = "days") ]
+  hosp_diff[ , dateOUT_diff := as.difftime(as.numeric(dateOUT - origin),
+                                            units = "days") ]
+  hosp_diff[ , dateCENS_diff := as.difftime(as.numeric(dateCENS - origin),
+                                             units = "days") ]
 
   hosp_aug = suppressWarnings(
-    augment( hosp_diff, subj, adm_number, label_3, t_start = dateIN_diff,
-             t_end = dateOUT_diff, t_cens = dateCENS_diff )
-  )
+    augment(hosp_diff, subj, adm_number, label_3, t_start = dateIN_diff,
+             t_end = dateOUT_diff, t_cens = dateCENS_diff)
+ )
 
-  expect_true( "augmented_num" %in% names( hosp_aug ) )
-  expect_s3_class( hosp_aug$augmented, "difftime" )
-  expect_type( hosp_aug$augmented_num, "double" )
-} )
+  expect_true("augmented_num" %in% names(hosp_aug))
+  expect_s3_class(hosp_aug$augmented, "difftime")
+  expect_type(hosp_aug$augmented_num, "double")
+})
 
-test_that( "supplied t_death avoids the censoring warning", {
+test_that("supplied t_death avoids the censoring warning", {
   expect_warning(
-    augment( test_hosp(), subj, adm_number, label_3, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS ),
+    augment(test_hosp(), subj, adm_number, label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, t_death = dateCENS),
     NA
-  )
-} )
+ )
+})
 
-test_that( "more_status creates expanded status columns", {
-  hosp_aug = augment_hosp( more_status = rehab_it )
+test_that("more_status creates expanded status columns", {
+  hosp_aug = augment_hosp(more_status = rehab_it)
 
-  expect_true( all( c( "status_exp", "status_exp_num", "n_status_exp" ) %in%
-                      names( hosp_aug ) ) )
-  expect_false( anyNA( hosp_aug$status_exp ) )
-  expect_false( anyNA( hosp_aug$status_exp_num ) )
-  expect_false( anyNA( hosp_aug$n_status_exp ) )
-} )
+  expect_true(all(c("status_exp", "status_exp_num", "n_status_exp") %in%
+                      names(hosp_aug)))
+  expect_false(anyNA(hosp_aug$status_exp))
+  expect_false(anyNA(hosp_aug$status_exp_num))
+  expect_false(anyNA(hosp_aug$n_status_exp))
+})
 
-test_that( "explicit NULL more_status matches omitted more_status", {
-  expect_identical( augment_hosp(), augment_hosp( more_status = NULL ) )
-} )
+test_that("explicit NULL more_status matches omitted more_status", {
+  expect_identical(augment_hosp(), augment_hosp(more_status = NULL))
+})

--- a/tests/testthat/test-augment.R
+++ b/tests/testthat/test-augment.R
@@ -281,3 +281,52 @@ test_that("more_status creates expanded status columns", {
 test_that("explicit NULL more_status matches omitted more_status", {
   expect_identical(augment_hosp(), augment_hosp(more_status = NULL))
 })
+
+test_that("two-value pattern with explicit t_death is augmented", {
+  hosp_aug = augment(test_hosp(), subj, adm_number, label_2,
+                     t_start = dateIN, t_end = dateOUT,
+                     t_cens = dateCENS, t_death = dateCENS)
+
+  expect_s3_class(hosp_aug, "data.table")
+  expect_true("status" %in% names(hosp_aug))
+})
+
+test_that("non-monotonic n_events stops augment with a helpful error", {
+  bad = test_hosp()
+  bad[ , adm_number := rev(adm_number), by = subj ]
+
+  expect_error(
+    suppressWarnings(
+      augment(bad, subj, adm_number, label_3, t_start = dateIN,
+               t_end = dateOUT, t_cens = dateCENS,
+               verbosity = "summary")
+   ),
+    "fix the issues and relaunch"
+ )
+})
+
+test_that("pattern with fewer than two unique values is rejected", {
+  single = test_hosp()
+  single[ , single_pattern := 0L ]
+
+  expect_error(
+    suppressWarnings(
+      augment(single, subj, adm_number, single_pattern, t_start = dateIN,
+               t_end = dateOUT, t_cens = dateCENS)
+   ),
+    "at least 2 elements"
+ )
+})
+
+test_that("pattern with more than three unique values is rejected", {
+  many = test_hosp()
+  many[ , many_pattern := rep(c(0L, 1L, 2L, 3L), length.out = .N) ]
+
+  expect_error(
+    suppressWarnings(
+      augment(many, subj, adm_number, many_pattern, t_start = dateIN,
+               t_end = dateOUT, t_cens = dateCENS)
+   ),
+    "2 or 3 unique values"
+ )
+})

--- a/tests/testthat/test-invariants.R
+++ b/tests/testthat/test-invariants.R
@@ -1,134 +1,134 @@
-column_classes = function( data ) {
-  vapply( data, function( x ) paste( class( x ), collapse = "/" ), character( 1L ) )
+column_classes = function(data) {
+  vapply(data, function(x) paste(class(x), collapse = "/"), character(1L))
 }
 
-test_that( "augment output matches the v2.0.9 Date golden fixture", {
+test_that("augment output matches the v2.0.9 Date golden fixture", {
   current = augment_hosp()
-  expected = readRDS( testthat::test_path( "fixtures", "augment-hosp-date.rds" ) )
+  expected = readRDS(testthat::test_path("fixtures", "augment-hosp-date.rds"))
 
-  expect_identical( current, expected )
-} )
+  expect_identical(current, expected)
+})
 
-test_that( "augment preserves core output structure across time classes", {
+test_that("augment preserves core output structure across time classes", {
   date_aug = augment_hosp()
 
   numeric_data = test_hosp()
-  numeric_data[ , dateIN := as.numeric( dateIN ) ]
-  numeric_data[ , dateOUT := as.numeric( dateOUT ) ]
-  numeric_data[ , dateCENS := as.numeric( dateCENS ) ]
+  numeric_data[ , dateIN := as.numeric(dateIN) ]
+  numeric_data[ , dateOUT := as.numeric(dateOUT) ]
+  numeric_data[ , dateCENS := as.numeric(dateCENS) ]
   numeric_aug = suppressWarnings(
-    augment( numeric_data, subj, adm_number, label_3, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS )
-  )
+    augment(numeric_data, subj, adm_number, label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS)
+ )
 
   diff_data = test_hosp()
-  origin = min( diff_data$dateIN )
-  diff_data[ , dateIN := as.difftime( as.numeric( dateIN - origin ),
-                                      units = "days" ) ]
-  diff_data[ , dateOUT := as.difftime( as.numeric( dateOUT - origin ),
-                                       units = "days" ) ]
-  diff_data[ , dateCENS := as.difftime( as.numeric( dateCENS - origin ),
-                                        units = "days" ) ]
+  origin = min(diff_data$dateIN)
+  diff_data[ , dateIN := as.difftime(as.numeric(dateIN - origin),
+                                      units = "days") ]
+  diff_data[ , dateOUT := as.difftime(as.numeric(dateOUT - origin),
+                                       units = "days") ]
+  diff_data[ , dateCENS := as.difftime(as.numeric(dateCENS - origin),
+                                        units = "days") ]
   diff_aug = suppressWarnings(
-    augment( diff_data, subj, adm_number, label_3, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS )
-  )
+    augment(diff_data, subj, adm_number, label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS)
+ )
 
-  core_columns = c( "status", "status_num", "n_status", "augmented" )
+  core_columns = c("status", "status_num", "n_status", "augmented")
 
-  expect_true( all( core_columns %in% names( date_aug ) ) )
-  expect_true( all( core_columns %in% names( numeric_aug ) ) )
-  expect_true( all( core_columns %in% names( diff_aug ) ) )
-  expect_true( "augmented_int" %in% names( date_aug ) )
-  expect_false( "augmented_int" %in% names( numeric_aug ) )
-  expect_true( "augmented_num" %in% names( diff_aug ) )
-  expect_identical( column_classes( date_aug )[ core_columns ],
-                    column_classes( readRDS( testthat::test_path(
-                      "fixtures", "augment-hosp-date.rds" ) ) )[ core_columns ] )
-} )
+  expect_true(all(core_columns %in% names(date_aug)))
+  expect_true(all(core_columns %in% names(numeric_aug)))
+  expect_true(all(core_columns %in% names(diff_aug)))
+  expect_true("augmented_int" %in% names(date_aug))
+  expect_false("augmented_int" %in% names(numeric_aug))
+  expect_true("augmented_num" %in% names(diff_aug))
+  expect_identical(column_classes(date_aug)[ core_columns ],
+                    column_classes(readRDS(testthat::test_path(
+                      "fixtures", "augment-hosp-date.rds")))[ core_columns ])
+})
 
-test_that( "augment expanded status columns remain stable", {
-  expanded = augment_hosp( more_status = rehab_it )
+test_that("augment expanded status columns remain stable", {
+  expanded = augment_hosp(more_status = rehab_it)
 
-  expect_true( all( c( "status_exp", "status_exp_num", "n_status_exp" ) %in%
-                      names( expanded ) ) )
-  expect_false( anyNA( expanded$status_exp ) )
-  expect_false( anyNA( expanded$status_exp_num ) )
-  expect_false( anyNA( expanded$n_status_exp ) )
-  expect_true( all( expanded$status_exp[ expanded$status == "DEAD" ] == "DEAD" ) )
-  expect_true( all( grepl( "_", expanded$status_exp[ expanded$status != "DEAD" ] ) ) )
-} )
+  expect_true(all(c("status_exp", "status_exp_num", "n_status_exp") %in%
+                      names(expanded)))
+  expect_false(anyNA(expanded$status_exp))
+  expect_false(anyNA(expanded$status_exp_num))
+  expect_false(anyNA(expanded$n_status_exp))
+  expect_true(all(expanded$status_exp[ expanded$status == "DEAD" ] == "DEAD"))
+  expect_true(all(grepl("_", expanded$status_exp[ expanded$status != "DEAD" ])))
+})
 
-test_that( "augment current by-reference behavior is documented by tests", {
+test_that("augment current by-reference behavior is documented by tests", {
   input = test_hosp()
-  before_names = data.table::copy( names( input ) )
-  before_key = data.table::copy( data.table::key( input ) )
+  before_names = data.table::copy(names(input))
+  before_key = data.table::copy(data.table::key(input))
 
   suppressWarnings(
-    augment( input, subj, pattern = label_3, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS )
-  )
+    augment(input, subj, pattern = label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS)
+ )
 
-  expect_false( "n_events" %in% before_names )
-  expect_true( "n_events" %in% names( input ) )
-  expect_false( identical( before_key, data.table::key( input ) ) )
-  expect_identical( data.table::key( input ), "subj" )
-} )
+  expect_false("n_events" %in% before_names)
+  expect_true("n_events" %in% names(input))
+  expect_false(identical(before_key, data.table::key(input)))
+  expect_identical(data.table::key(input), "subj")
+})
 
-test_that( "augment copy protects caller-owned data", {
+test_that("augment copy protects caller-owned data", {
   input = test_hosp()
-  before_names = data.table::copy( names( input ) )
-  before_key = data.table::copy( data.table::key( input ) )
+  before_names = data.table::copy(names(input))
+  before_key = data.table::copy(data.table::key(input))
 
   out = suppressWarnings(
-    augment( input, subj, pattern = label_3, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS, copy = TRUE )
-  )
+    augment(input, subj, pattern = label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, copy = TRUE)
+ )
 
-  expect_identical( names( input ), before_names )
-  expect_identical( data.table::key( input ), before_key )
-  expect_false( "n_events" %in% names( input ) )
-  expect_true( "n_events" %in% names( out ) )
-  expect_s3_class( out, "data.table" )
-} )
+  expect_identical(names(input), before_names)
+  expect_identical(data.table::key(input), before_key)
+  expect_false("n_events" %in% names(input))
+  expect_true("n_events" %in% names(out))
+  expect_s3_class(out, "data.table")
+})
 
-test_that( "augment copy protects data.frame inputs", {
-  input = as.data.frame( test_hosp() )
-  before_names = names( input )
-  before_class = class( input )
+test_that("augment copy protects data.frame inputs", {
+  input = as.data.frame(test_hosp())
+  before_names = names(input)
+  before_class = class(input)
 
   out = suppressWarnings(
-    augment( input, subj, adm_number, label_3, t_start = dateIN,
-             t_end = dateOUT, t_cens = dateCENS, copy = TRUE )
-  )
+    augment(input, subj, adm_number, label_3, t_start = dateIN,
+             t_end = dateOUT, t_cens = dateCENS, copy = TRUE)
+ )
 
-  expect_identical( names( input ), before_names )
-  expect_identical( class( input ), before_class )
-  expect_false( inherits( input, "data.table" ) )
-  expect_s3_class( out, "data.table" )
-} )
+  expect_identical(names(input), before_names)
+  expect_identical(class(input), before_class)
+  expect_false(inherits(input, "data.table"))
+  expect_s3_class(out, "data.table")
+})
 
-test_that( "polish current by-reference behavior is documented by tests", {
+test_that("polish current by-reference behavior is documented by tests", {
   input = augment_hosp()
-  before_names = data.table::copy( names( input ) )
-  before_key = data.table::copy( data.table::key( input ) )
+  before_names = data.table::copy(names(input))
+  before_key = data.table::copy(data.table::key(input))
 
-  polish( input, subj, label_3 )
+  polish(input, subj, label_3)
 
-  expect_identical( names( input ), before_names )
-  expect_false( identical( before_key, data.table::key( input ) ) )
-  expect_identical( data.table::key( input ), "subj" )
-} )
+  expect_identical(names(input), before_names)
+  expect_false(identical(before_key, data.table::key(input)))
+  expect_identical(data.table::key(input), "subj")
+})
 
-test_that( "polish copy protects caller-owned data", {
+test_that("polish copy protects caller-owned data", {
   input = augment_hosp()
-  before_names = data.table::copy( names( input ) )
-  before_key = data.table::copy( data.table::key( input ) )
+  before_names = data.table::copy(names(input))
+  before_key = data.table::copy(data.table::key(input))
 
-  out = polish( input, subj, label_3, copy = TRUE )
+  out = polish(input, subj, label_3, copy = TRUE)
 
-  expect_identical( names( input ), before_names )
-  expect_identical( data.table::key( input ), before_key )
-  expect_false( "index" %in% names( input ) )
-  expect_s3_class( out, "data.table" )
-} )
+  expect_identical(names(input), before_names)
+  expect_identical(data.table::key(input), before_key)
+  expect_false("index" %in% names(input))
+  expect_s3_class(out, "data.table")
+})

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -1,154 +1,154 @@
-test_that( "survplot returns fitted and Kaplan-Meier data", {
+test_that("survplot returns fitted and Kaplan-Meier data", {
   msm_fit = test_msm_fit()
   out = suppressMessages(
-    survplot( msm_fit, km = TRUE, out = "all", grid = 5 )
-  )
+    survplot(msm_fit, km = TRUE, out = "all", grid = 5)
+ )
 
-  expect_named( out, c( "p", "fitted", "km" ) )
-  expect_s3_class( out$p, "ggplot" )
-  expect_s3_class( out$fitted, "data.table" )
-  expect_s3_class( out$km, "data.table" )
-} )
+  expect_named(out, c("p", "fitted", "km"))
+  expect_s3_class(out$p, "ggplot")
+  expect_s3_class(out$fitted, "data.table")
+  expect_s3_class(out$km, "data.table")
+})
 
-test_that( "survplot can return without printing", {
+test_that("survplot can return without printing", {
   msm_fit = test_msm_fit()
   utils::capture.output(
-    out <- survplot( msm_fit, km = TRUE, out = "all", grid = 5,
-                     print_plot = FALSE )
-  )
+    out <- survplot(msm_fit, km = TRUE, out = "all", grid = 5,
+                     print_plot = FALSE)
+ )
 
-  expect_named( out, c( "p", "fitted", "km" ) )
-  expect_s3_class( out$p, "ggplot" )
-  expect_s3_class( out$fitted, "data.table" )
-  expect_s3_class( out$km, "data.table" )
-} )
+  expect_named(out, c("p", "fitted", "km"))
+  expect_s3_class(out$p, "ggplot")
+  expect_s3_class(out$fitted, "data.table")
+  expect_s3_class(out$km, "data.table")
+})
 
-test_that( "prevplot returns a ggplot object", {
+test_that("prevplot returns a ggplot object", {
   msm_fit = test_msm_fit()
-  hosp_aug = attr( msm_fit, "msmtools_data" )
+  hosp_aug = attr(msm_fit, "msmtools_data")
   prev = msm::prevalence.msm(
     msm_fit, covariates = "mean", ci = "normal",
-    times = seq( min( hosp_aug$augmented_int ), max( hosp_aug$augmented_int ),
-                 length.out = 4 )
-  )
+    times = seq(min(hosp_aug$augmented_int), max(hosp_aug$augmented_int),
+                 length.out = 4)
+ )
 
-  out = suppressMessages( prevplot( msm_fit, prev, ci = TRUE, M = FALSE ) )
+  out = suppressMessages(prevplot(msm_fit, prev, ci = TRUE, M = FALSE))
 
-  expect_s3_class( out, "ggplot" )
-} )
+  expect_s3_class(out, "ggplot")
+})
 
-test_that( "prevplot with M = TRUE returns a patchwork when available", {
-  testthat::skip_if_not_installed( "patchwork" )
+test_that("prevplot with M = TRUE returns a patchwork when available", {
+  testthat::skip_if_not_installed("patchwork")
   msm_fit = test_msm_fit()
-  hosp_aug = attr( msm_fit, "msmtools_data" )
+  hosp_aug = attr(msm_fit, "msmtools_data")
   prev = msm::prevalence.msm(
     msm_fit, covariates = "mean", ci = "normal",
-    times = seq( min( hosp_aug$augmented_int ), max( hosp_aug$augmented_int ),
-                 length.out = 4 )
-  )
+    times = seq(min(hosp_aug$augmented_int), max(hosp_aug$augmented_int),
+                 length.out = 4)
+ )
 
   out = suppressMessages(
-    prevplot( msm_fit, prev, ci = TRUE, M = TRUE, print_plot = FALSE )
-  )
+    prevplot(msm_fit, prev, ci = TRUE, M = TRUE, print_plot = FALSE)
+ )
 
-  expect_s3_class( out, "patchwork" )
-} )
+  expect_s3_class(out, "patchwork")
+})
 
-test_that( "prevplot can return without printing", {
+test_that("prevplot can return without printing", {
   msm_fit = test_msm_fit()
-  hosp_aug = attr( msm_fit, "msmtools_data" )
+  hosp_aug = attr(msm_fit, "msmtools_data")
   prev = msm::prevalence.msm(
     msm_fit, covariates = "mean", ci = "normal",
-    times = seq( min( hosp_aug$augmented_int ), max( hosp_aug$augmented_int ),
-                 length.out = 4 )
-  )
+    times = seq(min(hosp_aug$augmented_int), max(hosp_aug$augmented_int),
+                 length.out = 4)
+ )
   utils::capture.output(
-    out <- prevplot( msm_fit, prev, ci = TRUE, M = FALSE,
-                     print_plot = FALSE )
-  )
+    out <- prevplot(msm_fit, prev, ci = TRUE, M = FALSE,
+                     print_plot = FALSE)
+ )
 
-  expect_s3_class( out, "ggplot" )
-} )
+  expect_s3_class(out, "ggplot")
+})
 
-test_that( "plot verbosity controls messages", {
+test_that("plot verbosity controls messages", {
   msm_fit = test_msm_fit()
   quiet = utils::capture.output(
-    survplot( msm_fit, grid = 5, print_plot = FALSE ),
+    survplot(msm_fit, grid = 5, print_plot = FALSE),
     type = "message"
-  )
+ )
   summary = utils::capture.output(
-    survplot( msm_fit, grid = 5, print_plot = FALSE, verbosity = "summary" ),
+    survplot(msm_fit, grid = 5, print_plot = FALSE, verbosity = "summary"),
     type = "message"
-  )
+ )
 
-  expect_equal( quiet, character() )
-  expect_true( length( summary ) > 0L )
-} )
+  expect_equal(quiet, character())
+  expect_true(length(summary) > 0L)
+})
 
-test_that( "survplot validates plotting arguments", {
+test_that("survplot validates plotting arguments", {
   msm_fit = test_msm_fit()
 
   expect_error(
-    survplot( msm_fit, exacttimes = NA, print_plot = FALSE ),
+    survplot(msm_fit, exacttimes = NA, print_plot = FALSE),
     "exacttimes must be either TRUE or FALSE"
-  )
+ )
   expect_error(
-    survplot( msm_fit, km = c( TRUE, FALSE ), print_plot = FALSE ),
+    survplot(msm_fit, km = c(TRUE, FALSE), print_plot = FALSE),
     "km must be either TRUE or FALSE"
-  )
+ )
   expect_error(
-    survplot( msm_fit, print_plot = "yes" ),
+    survplot(msm_fit, print_plot = "yes"),
     "print_plot must be either TRUE or FALSE"
-  )
+ )
   expect_error(
-    survplot( msm_fit, from = 0, print_plot = FALSE ),
+    survplot(msm_fit, from = 0, print_plot = FALSE),
     "from must be a positive scalar numeric"
-  )
+ )
   expect_error(
-    survplot( msm_fit, to = "DEAD", print_plot = FALSE ),
+    survplot(msm_fit, to = "DEAD", print_plot = FALSE),
     "to must be a positive scalar numeric"
-  )
+ )
   expect_error(
-    survplot( msm_fit, grid = 0, print_plot = FALSE ),
+    survplot(msm_fit, grid = 0, print_plot = FALSE),
     "grid must be a positive scalar numeric"
-  )
+ )
   expect_error(
-    survplot( msm_fit, B = 0, print_plot = FALSE ),
+    survplot(msm_fit, B = 0, print_plot = FALSE),
     "B must be a positive scalar numeric"
-  )
+ )
   expect_error(
-    survplot( msm_fit, range = c( 1, Inf ), print_plot = FALSE ),
+    survplot(msm_fit, range = c(1, Inf), print_plot = FALSE),
     "range must be a finite numeric vector of two elements"
-  )
+ )
   expect_error(
-    survplot( msm_fit, times = numeric(), print_plot = FALSE ),
+    survplot(msm_fit, times = numeric(), print_plot = FALSE),
     "times must be a finite non-empty numeric vector"
-  )
-} )
+ )
+})
 
-test_that( "prevplot validates plotting arguments", {
+test_that("prevplot validates plotting arguments", {
   msm_fit = test_msm_fit()
-  hosp_aug = attr( msm_fit, "msmtools_data" )
+  hosp_aug = attr(msm_fit, "msmtools_data")
   prev = msm::prevalence.msm(
     msm_fit, covariates = "mean", ci = "normal",
-    times = seq( min( hosp_aug$augmented_int ), max( hosp_aug$augmented_int ),
-                 length.out = 4 )
-  )
+    times = seq(min(hosp_aug$augmented_int), max(hosp_aug$augmented_int),
+                 length.out = 4)
+ )
 
   expect_error(
-    prevplot( msm_fit, prev, exacttimes = NA, print_plot = FALSE ),
+    prevplot(msm_fit, prev, exacttimes = NA, print_plot = FALSE),
     "exacttimes must be either TRUE or FALSE"
-  )
+ )
   expect_error(
-    prevplot( msm_fit, prev, M = c( TRUE, FALSE ), print_plot = FALSE ),
+    prevplot(msm_fit, prev, M = c(TRUE, FALSE), print_plot = FALSE),
     "M must be either TRUE or FALSE"
-  )
+ )
   expect_error(
-    prevplot( msm_fit, prev, ci = NA, print_plot = FALSE ),
+    prevplot(msm_fit, prev, ci = NA, print_plot = FALSE),
     "ci must be either TRUE or FALSE"
-  )
+ )
   expect_error(
-    prevplot( msm_fit, prev, print_plot = "yes" ),
+    prevplot(msm_fit, prev, print_plot = "yes"),
     "print_plot must be either TRUE or FALSE"
-  )
-} )
+ )
+})

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -85,6 +85,96 @@ test_that("plot verbosity controls messages", {
   expect_true(length(summary) > 0L)
 })
 
+test_that("survplot with ci = 'normal' returns survival curves with bounds", {
+  msm_fit = test_msm_fit()
+  out = suppressMessages(
+    survplot(msm_fit, km = TRUE, ci = "normal", ci_km = "log",
+             out = "all", grid = 5, B = 2L, print_plot = FALSE)
+ )
+
+  expect_named(out, c("p", "fitted", "km"))
+  expect_s3_class(out$p, "ggplot")
+  expect_true(all(c("lwr", "upr") %in% names(out$fitted)))
+  expect_true(all(c("lwr", "upr") %in% names(out$km)))
+})
+
+test_that("survplot honours exacttimes = FALSE", {
+  msm_fit = test_msm_fit()
+  out = suppressMessages(
+    survplot(msm_fit, km = TRUE, exacttimes = FALSE, ci_km = "log",
+             out = "all", grid = 5, print_plot = FALSE)
+ )
+
+  expect_s3_class(out$p, "ggplot")
+  expect_false("time_exact" %in% names(out$km))
+})
+
+test_that("survplot honours interp = 'midpoint'", {
+  msm_fit = test_msm_fit()
+  out = suppressMessages(
+    survplot(msm_fit, km = TRUE, interp = "midpoint", out = "all",
+             grid = 5, print_plot = FALSE)
+ )
+
+  expect_s3_class(out$p, "ggplot")
+  expect_s3_class(out$km, "data.table")
+})
+
+test_that("survplot supports custom range and times", {
+  msm_fit = test_msm_fit()
+  rg = range(stats::model.extract(msm_fit$data$mf, "time"))
+  custom_times = seq(rg[1L], rg[2L], length.out = 6L)
+
+  out_range = suppressMessages(
+    survplot(msm_fit, range = rg, grid = 5, print_plot = FALSE)
+ )
+  out_times = suppressMessages(
+    survplot(msm_fit, times = custom_times, print_plot = FALSE)
+ )
+  out_times_inexact = suppressMessages(
+    survplot(msm_fit, times = custom_times, exacttimes = FALSE,
+             print_plot = FALSE)
+ )
+
+  expect_s3_class(out_range, "ggplot")
+  expect_s3_class(out_times, "ggplot")
+  expect_s3_class(out_times_inexact, "ggplot")
+})
+
+test_that("survplot out = 'fitted' / 'km' return shaped lists", {
+  msm_fit = test_msm_fit()
+  out_fitted = suppressMessages(
+    survplot(msm_fit, out = "fitted", grid = 5, print_plot = FALSE)
+ )
+  out_km = suppressMessages(
+    survplot(msm_fit, km = TRUE, out = "km", grid = 5, print_plot = FALSE)
+ )
+
+  expect_named(out_fitted, c("p", "fitted"))
+  expect_named(out_km, c("p", "km"))
+})
+
+test_that("survplot errors on invalid inputs", {
+  msm_fit = test_msm_fit()
+
+  expect_error(
+    survplot("not a msm fit", print_plot = FALSE),
+    "x must be a msm model"
+ )
+  expect_error(
+    survplot(msm_fit, to = 1, print_plot = FALSE),
+    "to must be an absorbing state"
+ )
+  expect_error(
+    survplot(msm_fit, km = FALSE, out = "km", grid = 5, print_plot = FALSE),
+    "km = TRUE"
+ )
+  expect_error(
+    survplot(msm_fit, km = FALSE, out = "all", grid = 5, print_plot = FALSE),
+    "km = TRUE"
+ )
+})
+
 test_that("survplot validates plotting arguments", {
   msm_fit = test_msm_fit()
 
@@ -123,6 +213,60 @@ test_that("survplot validates plotting arguments", {
   expect_error(
     survplot(msm_fit, times = numeric(), print_plot = FALSE),
     "times must be a finite non-empty numeric vector"
+ )
+})
+
+test_that("prevplot supports the ci = FALSE path", {
+  msm_fit = test_msm_fit()
+  hosp_aug = attr(msm_fit, "msmtools_data")
+  prev = msm::prevalence.msm(
+    msm_fit, covariates = "mean", ci = "normal",
+    times = seq(min(hosp_aug$augmented_int), max(hosp_aug$augmented_int),
+                length.out = 4)
+ )
+
+  out = suppressMessages(
+    prevplot(msm_fit, prev, ci = FALSE, M = FALSE, print_plot = FALSE)
+ )
+
+  expect_s3_class(out, "ggplot")
+})
+
+test_that("prevplot prints the combined layout when print_plot = TRUE", {
+  testthat::skip_if_not_installed("patchwork")
+  msm_fit = test_msm_fit()
+  hosp_aug = attr(msm_fit, "msmtools_data")
+  prev = msm::prevalence.msm(
+    msm_fit, covariates = "mean", ci = "normal",
+    times = seq(min(hosp_aug$augmented_int), max(hosp_aug$augmented_int),
+                length.out = 4)
+ )
+
+  utils::capture.output(
+    out <- suppressMessages(
+      prevplot(msm_fit, prev, ci = TRUE, M = TRUE, print_plot = TRUE)
+   )
+ )
+
+  expect_s3_class(out, "patchwork")
+})
+
+test_that("prevplot errors on invalid input classes", {
+  msm_fit = test_msm_fit()
+  hosp_aug = attr(msm_fit, "msmtools_data")
+  prev = msm::prevalence.msm(
+    msm_fit, covariates = "mean",
+    times = seq(min(hosp_aug$augmented_int), max(hosp_aug$augmented_int),
+                length.out = 4)
+ )
+
+  expect_error(
+    prevplot("not a msm fit", prev, print_plot = FALSE),
+    "x must be a msm model"
+ )
+  expect_error(
+    prevplot(msm_fit, "not a list", print_plot = FALSE),
+    "prev.obj must be a list"
  )
 })
 

--- a/tests/testthat/test-polish.R
+++ b/tests/testthat/test-polish.R
@@ -109,6 +109,33 @@ test_that("polish reports checked missing values clearly", {
  )
 })
 
+test_that("polish errors on missing mandatory arguments", {
+  hosp_aug = augment_hosp()
+
+  expect_error(polish(), "dataset of class")
+  expect_error(polish("not a data.frame"), "dataset of class")
+  expect_error(polish(hosp_aug), "variable of keying")
+  expect_error(polish(hosp_aug, subj), "pattern must be provided")
+})
+
+test_that("polish handles a two-value pattern schema", {
+  hosp_aug = augment_hosp(pattern = "label_2")
+  cleaned = polish(data.table::copy(hosp_aug), subj, label_2)
+
+  expect_s3_class(cleaned, "data.table")
+})
+
+test_that("polish reports check_NA success when there are no missing values", {
+  hosp_aug = augment_hosp()
+  output = utils::capture.output(
+    polish(data.table::copy(hosp_aug), subj, label_3,
+           check_NA = TRUE, verbosity = "summary"),
+    type = "message"
+ )
+
+  expect_true(any(grepl("no missing values", output)))
+})
+
 test_that("polish accepts summary verbosity", {
   hosp_aug = augment_hosp()
   output = utils::capture.output(

--- a/tests/testthat/test-polish.R
+++ b/tests/testthat/test-polish.R
@@ -1,123 +1,123 @@
-test_that( "polish leaves data unchanged when no duplicate transition exists", {
+test_that("polish leaves data unchanged when no duplicate transition exists", {
   hosp_aug = augment_hosp()
-  hosp_clean = polish( data.table::copy( hosp_aug ), subj, label_3 )
+  hosp_clean = polish(data.table::copy(hosp_aug), subj, label_3)
 
-  expect_equal( as.data.frame( hosp_clean ), as.data.frame( hosp_aug ) )
-} )
+  expect_equal(as.data.frame(hosp_clean), as.data.frame(hosp_aug))
+})
 
-test_that( "polish removes subjects with duplicate transition times", {
+test_that("polish removes subjects with duplicate transition times", {
   hosp_aug = augment_hosp()
-  duplicate_input = data.table::copy( hosp_aug )
-  rows = which( duplicate_input$subj == 1 & duplicate_input$status != "DEAD" )
+  duplicate_input = data.table::copy(hosp_aug)
+  rows = which(duplicate_input$subj == 1 & duplicate_input$status != "DEAD")
   duplicate_input[ rows[ 2 ], augmented := duplicate_input[ rows[ 1 ], augmented ] ]
   duplicate_input[ rows[ 2 ], augmented_int := duplicate_input[ rows[ 1 ], augmented_int ] ]
 
-  hosp_clean = polish( duplicate_input, subj, label_3 )
+  hosp_clean = polish(duplicate_input, subj, label_3)
 
-  expect_false( 1 %in% hosp_clean$subj )
-  expect_lt( nrow( hosp_clean ), nrow( hosp_aug ) )
-  expect_equal( data.table::uniqueN( hosp_clean$subj ), 9L )
-} )
+  expect_false(1 %in% hosp_clean$subj)
+  expect_lt(nrow(hosp_clean), nrow(hosp_aug))
+  expect_equal(data.table::uniqueN(hosp_clean$subj), 9L)
+})
 
-test_that( "polish returns a data.table", {
+test_that("polish returns a data.table", {
   hosp_aug = augment_hosp()
-  hosp_clean = polish( data.table::copy( hosp_aug ), subj, label_3 )
+  hosp_clean = polish(data.table::copy(hosp_aug), subj, label_3)
 
-  expect_s3_class( hosp_clean, "data.table" )
-  expect_s3_class( as.data.frame( hosp_clean ), "data.frame" )
-} )
+  expect_s3_class(hosp_clean, "data.table")
+  expect_s3_class(as.data.frame(hosp_clean), "data.frame")
+})
 
-test_that( "polish resolves time columns explicitly", {
+test_that("polish resolves time columns explicitly", {
   hosp_aug = augment_hosp()
 
   expect_identical(
-    polish( data.table::copy( hosp_aug ), subj, label_3 ),
-    polish( data.table::copy( hosp_aug ), subj, label_3, time = NULL )
-  )
+    polish(data.table::copy(hosp_aug), subj, label_3),
+    polish(data.table::copy(hosp_aug), subj, label_3, time = NULL)
+ )
   expect_identical(
-    polish( data.table::copy( hosp_aug ), subj, label_3 ),
-    polish( data.table::copy( hosp_aug ), subj, label_3, time = augmented_int )
-  )
+    polish(data.table::copy(hosp_aug), subj, label_3),
+    polish(data.table::copy(hosp_aug), subj, label_3, time = augmented_int)
+ )
 
-  fallback_input = data.table::copy( hosp_aug )
+  fallback_input = data.table::copy(hosp_aug)
   fallback_input[ , augmented_num := augmented_int ]
   fallback_input[ , augmented_int := NULL ]
-  fallback = polish( fallback_input, subj, label_3 )
+  fallback = polish(fallback_input, subj, label_3)
 
-  expect_s3_class( fallback, "data.table" )
-  expect_true( "augmented_num" %in% names( fallback ) )
-} )
+  expect_s3_class(fallback, "data.table")
+  expect_true("augmented_num" %in% names(fallback))
+})
 
-test_that( "polish validates logical flags", {
+test_that("polish validates logical flags", {
   hosp_aug = augment_hosp()
 
   expect_error(
-    polish( data.table::copy( hosp_aug ), subj, label_3, copy = "yes" ),
+    polish(data.table::copy(hosp_aug), subj, label_3, copy = "yes"),
     "copy must be either TRUE or FALSE"
-  )
+ )
   expect_error(
-    polish( data.table::copy( hosp_aug ), subj, label_3, check_NA = NA ),
+    polish(data.table::copy(hosp_aug), subj, label_3, check_NA = NA),
     "check_NA must be either TRUE or FALSE"
-  )
-} )
+ )
+})
 
-test_that( "polish validates columns and pattern schemas", {
+test_that("polish validates columns and pattern schemas", {
   hosp_aug = augment_hosp()
 
-  no_time = data.table::copy( hosp_aug )
+  no_time = data.table::copy(hosp_aug)
   no_time[ , augmented_int := NULL ]
   expect_error(
-    polish( no_time, subj, label_3 ),
+    polish(no_time, subj, label_3),
     "time must be provided"
-  )
+ )
   expect_error(
-    polish( data.table::copy( hosp_aug ), missing_subject, label_3 ),
+    polish(data.table::copy(hosp_aug), missing_subject, label_3),
     "not present in data: missing_subject"
-  )
+ )
   expect_error(
-    polish( data.table::copy( hosp_aug ), subj, missing_pattern ),
+    polish(data.table::copy(hosp_aug), subj, missing_pattern),
     "not present in data: missing_pattern"
-  )
+ )
   expect_error(
-    polish( data.table::copy( hosp_aug ), subj, label_3, time = missing_time ),
+    polish(data.table::copy(hosp_aug), subj, label_3, time = missing_time),
     "not present in data: missing_time"
-  )
+ )
 
-  one_value = data.table::copy( hosp_aug )
+  one_value = data.table::copy(hosp_aug)
   one_value[ , one_pattern := "alive" ]
   expect_error(
-    polish( one_value, subj, one_pattern ),
+    polish(one_value, subj, one_pattern),
     "pattern must have 2 or 3 unique values"
-  )
+ )
 
-  four_values = data.table::copy( hosp_aug )
-  four_values[ , four_pattern := rep( c( "a", "b", "c", "d" ), length.out = .N ) ]
+  four_values = data.table::copy(hosp_aug)
+  four_values[ , four_pattern := rep(c("a", "b", "c", "d"), length.out = .N) ]
   expect_error(
-    polish( four_values, subj, four_pattern ),
+    polish(four_values, subj, four_pattern),
     "pattern must have 2 or 3 unique values"
-  )
-} )
+ )
+})
 
-test_that( "polish reports checked missing values clearly", {
+test_that("polish reports checked missing values clearly", {
   hosp_aug = augment_hosp()
-  missing_time = data.table::copy( hosp_aug )
+  missing_time = data.table::copy(hosp_aug)
   missing_time[ 1L, augmented_int := NA_real_ ]
 
   expect_error(
-    polish( missing_time, subj, label_3, check_NA = TRUE ),
+    polish(missing_time, subj, label_3, check_NA = TRUE),
     "missing values detected in: augmented_int"
-  )
-} )
+ )
+})
 
-test_that( "polish accepts summary verbosity", {
+test_that("polish accepts summary verbosity", {
   hosp_aug = augment_hosp()
   output = utils::capture.output(
     hosp_clean <- polish(
-      data.table::copy( hosp_aug ), subj, label_3, verbosity = "summary"
-    ),
+      data.table::copy(hosp_aug), subj, label_3, verbosity = "summary"
+   ),
     type = "message"
-  )
+ )
 
-  expect_true( length( output ) > 0L )
-  expect_s3_class( hosp_clean, "data.table" )
-} )
+  expect_true(length(output) > 0L)
+  expect_s3_class(hosp_clean, "data.table")
+})


### PR DESCRIPTION
## Summary

Follow-up to #20. Targeted audit pass over the 2.1.3 release that lands a few inconsistencies caught after merge. No version bump.

- **Paren-style normalisation.** Commit 40f51ce moved the plotting sources to the unspaced \`foo(x, y)\` convention; \`R/augment.R\` and all \`tests/testthat/*.R\` had not been brought along. They are now aligned. Mechanical diff, full testthat suite (136 tests) passes unchanged.
- **README baseline.** Restore the \"From version 2.0.4\" CRAN-baseline anchor and append a separate sentence describing the 2.1.3 patchwork demotion. The earlier rewrite conflated the two milestones.
- **\`prevplot()\` \`@details\`.** Document the patchwork requirement for \`M = TRUE\` so \`?prevplot\` shows the dependency contract, not just the runtime error.
- **Percent labeller.** Switch \`digits = 0\` → \`digits = 1\` so prevalence axis labels keep one-decimal accuracy (\"12.3%\"), matching the pre-2.1.3 \`scales::percent\` default.
- **Benchmark baseline.** Annotate \`dev/benchmarks/baseline-2.0.9.md\` so readers know the captured figures predate the dependency tightening. The directory remains excluded from package builds.

## Test plan

- [x] \`devtools::test()\` — 136 / 136 pass after the paren-style rewrite.
- [x] \`R CMD check --as-cran\` — identical status to the 2.1.3 release check (only NOTE is the expected archived-package CRAN-incoming feasibility; PDF/HTML manual errors are local LaTeX/HTML-Tidy env, not package issues).
- [x] \`_R_CHECK_DEPENDS_ONLY_=true R CMD check --as-cran --no-manual --no-build-vignettes\` — clean; patchwork test skips correctly when the package is absent.