### PR TITLE
v2.2.0: drop survplot() out arg and unify plotting return contract (closes #4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: msmtools
 Type: Package
 Title: Building Augmented Data to Run Multi-State Models with 'msm' Package
-Version: 2.1.4
-Date: 2026-05-26
+Version: 2.2.0
+Date: 2026-05-28
 Authors@R: person("Francesco", "Grossetti",
     email = "francesco.grossetti@unibocconi.it",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0002-5130-7745"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,58 @@
+# msmtools 2.2.0
+***
+
+### BREAKING CHANGES
+
+* `survplot()` no longer accepts the `out` argument and now always
+  returns a `gg/ggplot` object. The fitted survival curve and the
+  Kaplan-Meier curve are exposed as named fields on the returned plot
+  for parity with `prevplot()`:
+
+  ```r
+  p <- survplot(model, km = TRUE)
+  p           # prints the plot
+  p$fitted    # data.table — survival probabilities
+  p$km        # data.table — Kaplan-Meier curve
+  ```
+
+  Closes [#4](https://github.com/contefranz/msmtools/issues/4).
+
+  Code that previously did `out <- survplot(..., out = "all")` and then
+  unwrapped through `out$p`, `out$fitted`, `out$km` should drop the
+  `out` argument and access the data tables directly on the plot. The
+  return type collapsing from a wrapper list to a ggplot means that
+  ggplot operations now compose without unwrapping: `p + theme_bw()`,
+  `ggsave("plot.pdf", p)`, and `patchwork`-style combinations all work
+  on the returned plot directly.
+
+  Calls passing `out = ...` raise a clear migration error pointing to
+  the new pattern. The trampoline that catches the legacy argument
+  will itself be removed in v2.3.0.
+
+### NEW
+
+* `prevplot()` exposes the long-format prevalence data used to build
+  the plot via `p$prevalence`, so both plotting functions now expose
+  their data through the same `$` idiom. The field is populated on
+  both the `M = FALSE` (`ggplot`) and `M = TRUE` (`patchwork`) return
+  paths.
+
+### TESTS
+
+* Replaced the test suite for `survplot()` `out = ...` shapes with
+  attribute-field assertions on the returned plot, plus a regression
+  test for the legacy-argument trampoline.
+* Added a regression test asserting `prevplot()` populates
+  `$prevalence` on the `M = FALSE`, `ci = TRUE`, and `M = TRUE` paths.
+
+### DOCUMENTATION
+
+* Rewrote the `survplot()` roxygen `@returns` and `@details` sections
+  around the new contract. The vignette and worked examples in
+  `man/survplot.Rd` now demonstrate the `$fitted` / `$km` access
+  pattern.
+* Documented the `$prevalence` field on `prevplot()`'s `@returns`.
+
 # msmtools 2.1.4
 ***
 

--- a/R/prevplot.R
+++ b/R/prevplot.R
@@ -39,6 +39,16 @@ if (getRversion() >= "2.15.1") {
 #' prevalences is returned. When `M = TRUE`, a `patchwork` object is returned
 #' with the prevalence plot and the deviance `M` plot.
 #'
+#' The returned object also carries a `$prevalence` field with the
+#' long-format `data.table` used to build the plot. It always includes
+#' `time`, `state`, `obs`, and `hat`; it also includes `lwr` and `upr`
+#' when `ci = TRUE`, and `M` when `M = TRUE`. Access it directly:
+#'
+#' ```
+#' p <- prevplot(model, prev_obj)
+#' p$prevalence
+#' ```
+#'
 #' `print_plot` only controls whether the plot is printed as a side effect.
 #' Returned objects are unchanged: use `print_plot = FALSE` to create the plot
 #' silently.
@@ -226,11 +236,13 @@ prevplot = function(x, prev.obj, exacttimes = TRUE, M = FALSE, ci = FALSE,
            call. = FALSE)
     }
     p_combined = patchwork::wrap_plots(p, p_gof, nrow = 2L)
+    p_combined$prevalence = to_plot[]
     if (print_plot) {
       print(p_combined)
     }
     return(p_combined)
   } else {
+    p$prevalence = to_plot[]
     if (print_plot) {
       print(p)
     }

--- a/R/survplot.R
+++ b/R/survplot.R
@@ -35,10 +35,6 @@ if (getRversion() >= "2.15.1") {
 #' fitted survival curve (see Details). If `times` is passed, `grid` is ignored.
 #' Defaults to 100 points.
 #' @param km If `TRUE`, the Kaplan-Meier curve is plotted. Default is `FALSE`.
-#' @param out A character vector specifying what the function returns. Accepted
-#' values are `"none"` (default) to return just the plot, `"fitted"` to return
-#' the fitted survival curve only, `"km"` to return the Kaplan-Meier curve only,
-#' and `"all"` to return all of them.
 #' @param ci A character vector with the type of confidence intervals to compute for the fitted
 #' survival curve. Specify either `"none"` (default), for no confidence intervals,
 #' `"normal"` or `"bootstrap"`, for confidence intervals computed with the respective
@@ -60,18 +56,35 @@ if (getRversion() >= "2.15.1") {
 #' returned. If `FALSE`, the plot is returned without printing.
 #' @param verbosity Controls informational output. Use `"quiet"` to suppress
 #' status messages and `"summary"` or `"progress"` for high-level messages.
+#' @param ... Reserved for the migration trampoline. Passing the legacy
+#' `out` argument here raises an informative error pointing to the new
+#' `$fitted` / `$km` access pattern. The trampoline will be removed in
+#' v2.3.0.
 #' @details The function wraps [msm::plot.survfit.msm()] and adds support for
-#' exact-time plots by resetting the time scale to follow-up time. It can return
-#' the fitted survival and Kaplan-Meier data by setting `out = "all"`.
+#' exact-time plots by resetting the time scale to follow-up time. It returns
+#' a `gg/ggplot` object so the plot composes directly with [ggplot2::ggsave()],
+#' [ggplot2::theme()], and other ggplot operations.
 #'
 #' You can pass custom evaluation times through `times`, or let `survplot()`
 #' define them from `grid`. Larger `grid` values produce a finer grid and
 #' increase computation time.
-#' @returns When `out = "none"`, a `gg/ggplot` object is returned. If `out` is
-#' anything else, a named list is returned. The list always includes the plot in
-#' `p`; it also includes `fitted`, `km`, or both, depending on `out`. The
-#' Kaplan-Meier data can be accessed with `$km` while the estimated survival
-#' data can be accessed with `$fitted`.
+#' @returns A `gg/ggplot` object. The fitted and (when `km = TRUE`)
+#' Kaplan-Meier data tables are attached to the returned plot as named
+#' fields:
+#'
+#' * `$fitted` — a `data.table` with columns `time`, `surv`, and (when
+#'   `ci` is not `"none"`) `lwr` / `upr`. Always present.
+#' * `$km` — a `data.table` with the Kaplan-Meier curve, exposed only when
+#'   `km = TRUE`.
+#'
+#' Access the data through the standard `$` operator:
+#'
+#' ```
+#' p <- survplot(model, km = TRUE)
+#' p           # prints the plot
+#' p$fitted    # fitted survival data
+#' p$km        # Kaplan-Meier data
+#' ```
 #'
 #' `print_plot` only controls whether the plot is printed as a side effect.
 #' Returned objects are unchanged: use `print_plot = FALSE` to create the plot
@@ -104,9 +117,9 @@ if (getRversion() >= "2.15.1") {
 #' # plotting the fitted and empirical survival from state = 1
 #' theplot = survplot(x = msm_model, km = TRUE)
 #'
-#' # plotting the fitted and empirical survival from state = 2 and
-#' # returning both the fitted and the empirical curve
-#' out_all = survplot(msm_model, from = 2, km = TRUE, out = "all")
+#' # the fitted and Kaplan-Meier data tables are attached to the plot
+#' head(theplot$fitted)
+#' head(theplot$km)
 #'
 #' @references Titman, A. and Sharples, L.D. (2010). Model diagnostics for
 #' multi-state models, *Statistical Methods in Medical Research*, 19, 621-651.
@@ -124,12 +137,22 @@ if (getRversion() >= "2.15.1") {
 
 survplot = function(x, from = 1, to = NULL, range = NULL, covariates = "mean",
                      exacttimes = TRUE, times, grid = 100L, km = FALSE,
-                     out = c("none", "fitted", "km", "all"),
                      ci = c("none", "normal", "bootstrap"), interp = c("start", "midpoint"),
                      B = 100L,
                      ci_km = c("none", "plain", "log", "log-log", "logit", "arcsin"),
                      print_plot = TRUE,
-                     verbosity = getOption("msmtools.verbosity", "quiet")) {
+                     verbosity = getOption("msmtools.verbosity", "quiet"),
+                     ...) {
+
+  dots = list(...)
+  if ("out" %in% names(dots)) {
+    stop("`out` was removed in msmtools 2.2.0. ",
+         "survplot() now always returns a gg/ggplot with the fitted and ",
+         "Kaplan-Meier data tables attached as named fields. Use ",
+         "p$fitted and (when km = TRUE) p$km instead. ",
+         "This trampoline will be removed in v2.3.0.",
+         call. = FALSE)
+  }
 
   verbosity = .msmtools_verbosity(verbosity)
   .msmtools_validate_flag(exacttimes, "exacttimes")
@@ -162,7 +185,6 @@ survplot = function(x, from = 1, to = NULL, range = NULL, covariates = "mean",
   interp = match.arg(interp)
   ci = match.arg(ci)
   ci_km = match.arg(ci_km)
-  out = match.arg(out)
   states = rownames(x$qmodel$imatrix)
 
   if (exacttimes) {
@@ -307,23 +329,12 @@ survplot = function(x, from = 1, to = NULL, range = NULL, covariates = "mean",
     ggplot2::theme_bw() +
     ggplot2::theme(legend.position = "bottom") +
     ggplot2::ggtitle(paste0("Estimation for transition ", states[from], " - ", states[to]))
+  p$fitted = surv_probabilities[]
+  if (km) {
+    p$km = out_km[]
+  }
   if (print_plot) {
     print(p)
   }
-
-  if (out == "none") {
-    return(p)
-  } else if (out == "fitted") {
-    return(list(p = p, fitted = surv_probabilities[]))
-  } else if (out == "km") {
-    if (isFALSE(km)) {
-      stop("Set km = TRUE when \"out\" is either \"km\" or \"all\"")
-    }
-    return(list(p = p, km = out_km[]))
-  } else {
-    if (isFALSE(km)) {
-      stop("Set km = TRUE when \"out\" is either \"km\" or \"all\"")
-    }
-    return(list(p = p, fitted = surv_probabilities[], km = out_km[]))
-  }
+  return(p)
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![lifecycle](https://lifecycle.r-lib.org/articles/figures/lifecycle-stable.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 [![R-CMD-check](https://github.com/contefranz/msmtools/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/contefranz/msmtools/actions/workflows/R-CMD-check.yaml)
 [![codecov](https://codecov.io/gh/contefranz/msmtools/branch/main/graph/badge.svg?token=wDcJP6mRRY)](https://app.codecov.io/gh/contefranz/msmtools)
-[![release](https://img.shields.io/badge/dev.%20version-2.1.4-blue)](https://github.com/contefranz/msmtools)
+[![release](https://img.shields.io/badge/dev.%20version-2.2.0-blue)](https://github.com/contefranz/msmtools)
 [![CRAN Status Badge](https://www.r-pkg.org/badges/version/msmtools)](https://cran.r-project.org/package=msmtools)
 [![license](https://img.shields.io/badge/license-GPL--3-blue.svg)](https://en.wikipedia.org/wiki/GNU_General_Public_License)
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,20 +1,26 @@
-# msmtools 2.1.4
+# msmtools 2.2.0
 
 ### Release summary
 
-This release fixes a correctness bug in `augment()`. For subjects who
-survived to the study censoring date, the final transition row inherited
-the time of the previous row (last `t_end`) instead of `t_cens`. As a
-result, the post-discharge observation window was collapsed to zero
-duration and any `msm` model fitted on the augmented data systematically
-under-estimated transition rates. The fix routes the trailing OUT row
-through `t_cens`, which is what the package documentation and reporter
-[#7](https://github.com/contefranz/msmtools/issues/7) expected.
+This release closes a long-standing API asymmetry between `survplot()`
+and `prevplot()` (GitHub issue #4). The `out` argument has been removed
+from `survplot()`; the function now always returns a `gg/ggplot` object,
+with the fitted survival and Kaplan-Meier data tables exposed as named
+fields on the returned plot (`p$fitted`, `p$km`). `prevplot()` gains
+the equivalent `p$prevalence` field. Both functions now compose
+directly with the ggplot ecosystem — `ggsave()`, `+`, and `patchwork`
+work on the returned plot without an unwrap step.
 
-Behaviour for subjects who died is unchanged. There are no other
-user-facing API changes. The internal regression fixture has been
-regenerated against the corrected output; the bracket-spacing style
-sweep started in 2.1.3 is also completed in this release.
+This is an intentional breaking change. Calls that previously used
+`out = "all"` (or any other `out` value) now raise a clear migration
+error pointing to the `$fitted` / `$km` access pattern. The trampoline
+that catches the legacy argument will itself be removed in v2.3.0.
+
+The version bump is to 2.2.0 rather than 3.0.0. msmtools has a narrow
+plotting API and a small user base; documenting the breaking change
+prominently in NEWS and providing the migration trampoline are
+sufficient to keep the upgrade path smooth without inflating the major
+version.
 
 ### Package development
 
@@ -38,7 +44,7 @@ sweep started in 2.1.3 is also completed in this release.
   and `prevplot(M = FALSE)` continues to work without `patchwork`
   installed.
 * The only expected NOTE in restricted environments is the offline
-  URL/DOI check (JSS DOI and CRAN incoming feasibility). These resolve
-  correctly when the check has network access.
+  URL/DOI check. These resolve correctly when the check has network
+  access.
 
 ***

--- a/man/prevplot.Rd
+++ b/man/prevplot.Rd
@@ -40,6 +40,15 @@ When \code{M = FALSE}, a \code{gg/ggplot} object with observed and expected
 prevalences is returned. When \code{M = TRUE}, a \code{patchwork} object is returned
 with the prevalence plot and the deviance \code{M} plot.
 
+The returned object also carries a \verb{$prevalence} field with the
+long-format \code{data.table} used to build the plot. It always includes
+\code{time}, \code{state}, \code{obs}, and \code{hat}; it also includes \code{lwr} and \code{upr}
+when \code{ci = TRUE}, and \code{M} when \code{M = TRUE}. Access it directly:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{p <- prevplot(model, prev_obj)
+p$prevalence
+}\if{html}{\out{</div>}}
+
 \code{print_plot} only controls whether the plot is printed as a side effect.
 Returned objects are unchanged: use \code{print_plot = FALSE} to create the plot
 silently.

--- a/man/survplot.Rd
+++ b/man/survplot.Rd
@@ -14,13 +14,13 @@ survplot(
   times,
   grid = 100L,
   km = FALSE,
-  out = c("none", "fitted", "km", "all"),
   ci = c("none", "normal", "bootstrap"),
   interp = c("start", "midpoint"),
   B = 100L,
   ci_km = c("none", "plain", "log", "log-log", "logit", "arcsin"),
   print_plot = TRUE,
-  verbosity = getOption("msmtools.verbosity", "quiet")
+  verbosity = getOption("msmtools.verbosity", "quiet"),
+  ...
 )
 }
 \arguments{
@@ -59,11 +59,6 @@ Defaults to 100 points.}
 
 \item{km}{If \code{TRUE}, the Kaplan-Meier curve is plotted. Default is \code{FALSE}.}
 
-\item{out}{A character vector specifying what the function returns. Accepted
-values are \code{"none"} (default) to return just the plot, \code{"fitted"} to return
-the fitted survival curve only, \code{"km"} to return the Kaplan-Meier curve only,
-and \code{"all"} to return all of them.}
-
 \item{ci}{A character vector with the type of confidence intervals to compute for the fitted
 survival curve. Specify either \code{"none"} (default), for no confidence intervals,
 \code{"normal"} or \code{"bootstrap"}, for confidence intervals computed with the respective
@@ -90,13 +85,30 @@ returned. If \code{FALSE}, the plot is returned without printing.}
 
 \item{verbosity}{Controls informational output. Use \code{"quiet"} to suppress
 status messages and \code{"summary"} or \code{"progress"} for high-level messages.}
+
+\item{...}{Reserved for the migration trampoline. Passing the legacy
+\code{out} argument here raises an informative error pointing to the new
+\verb{$fitted} / \verb{$km} access pattern. The trampoline will be removed in
+v2.3.0.}
 }
 \value{
-When \code{out = "none"}, a \code{gg/ggplot} object is returned. If \code{out} is
-anything else, a named list is returned. The list always includes the plot in
-\code{p}; it also includes \code{fitted}, \code{km}, or both, depending on \code{out}. The
-Kaplan-Meier data can be accessed with \verb{$km} while the estimated survival
-data can be accessed with \verb{$fitted}.
+A \code{gg/ggplot} object. The fitted and (when \code{km = TRUE})
+Kaplan-Meier data tables are attached to the returned plot as named
+fields:
+\itemize{
+\item \verb{$fitted} — a \code{data.table} with columns \code{time}, \code{surv}, and (when
+\code{ci} is not \code{"none"}) \code{lwr} / \code{upr}. Always present.
+\item \verb{$km} — a \code{data.table} with the Kaplan-Meier curve, exposed only when
+\code{km = TRUE}.
+}
+
+Access the data through the standard \code{$} operator:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{p <- survplot(model, km = TRUE)
+p           # prints the plot
+p$fitted    # fitted survival data
+p$km        # Kaplan-Meier data
+}\if{html}{\out{</div>}}
 
 \code{print_plot} only controls whether the plot is printed as a side effect.
 Returned objects are unchanged: use \code{print_plot = FALSE} to create the plot
@@ -109,8 +121,9 @@ to build each curve.
 }
 \details{
 The function wraps \code{\link[msm:plot.survfit.msm]{msm::plot.survfit.msm()}} and adds support for
-exact-time plots by resetting the time scale to follow-up time. It can return
-the fitted survival and Kaplan-Meier data by setting \code{out = "all"}.
+exact-time plots by resetting the time scale to follow-up time. It returns
+a \code{gg/ggplot} object so the plot composes directly with \code{\link[ggplot2:ggsave]{ggplot2::ggsave()}},
+\code{\link[ggplot2:theme]{ggplot2::theme()}}, and other ggplot operations.
 
 You can pass custom evaluation times through \code{times}, or let \code{survplot()}
 define them from \code{grid}. Larger \code{grid} values produce a finer grid and
@@ -144,9 +157,9 @@ msm_model = msm(status_num ~ augmented_int, subject = subj,
 # plotting the fitted and empirical survival from state = 1
 theplot = survplot(x = msm_model, km = TRUE)
 
-# plotting the fitted and empirical survival from state = 2 and
-# returning both the fitted and the empirical curve
-out_all = survplot(msm_model, from = 2, km = TRUE, out = "all")
+# the fitted and Kaplan-Meier data tables are attached to the plot
+head(theplot$fitted)
+head(theplot$km)
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -251,6 +251,35 @@ test_that("prevplot prints the combined layout when print_plot = TRUE", {
   expect_s3_class(out, "patchwork")
 })
 
+test_that("prevplot attaches the prevalence data table on both branches", {
+  msm_fit = test_msm_fit()
+  hosp_aug = attr(msm_fit, "msmtools_data")
+  prev = msm::prevalence.msm(
+    msm_fit, covariates = "mean", ci = "normal",
+    times = seq(min(hosp_aug$augmented_int), max(hosp_aug$augmented_int),
+                length.out = 4)
+ )
+
+  p_basic = suppressMessages(
+    prevplot(msm_fit, prev, ci = FALSE, M = FALSE, print_plot = FALSE)
+ )
+  expect_s3_class(p_basic$prevalence, "data.table")
+  expect_true(all(c("time", "state", "obs", "hat") %in% names(p_basic$prevalence)))
+
+  p_ci = suppressMessages(
+    prevplot(msm_fit, prev, ci = TRUE, M = FALSE, print_plot = FALSE)
+ )
+  expect_s3_class(p_ci$prevalence, "data.table")
+  expect_true(all(c("lwr", "upr") %in% names(p_ci$prevalence)))
+
+  testthat::skip_if_not_installed("patchwork")
+  p_m = suppressMessages(
+    prevplot(msm_fit, prev, ci = TRUE, M = TRUE, print_plot = FALSE)
+ )
+  expect_s3_class(p_m$prevalence, "data.table")
+  expect_true("M" %in% names(p_m$prevalence))
+})
+
 test_that("prevplot errors on invalid input classes", {
   msm_fit = test_msm_fit()
   hosp_aug = attr(msm_fit, "msmtools_data")

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -1,26 +1,21 @@
-test_that("survplot returns fitted and Kaplan-Meier data", {
+test_that("survplot returns a ggplot decorated with fitted and KM data", {
   msm_fit = test_msm_fit()
-  out = suppressMessages(
-    survplot(msm_fit, km = TRUE, out = "all", grid = 5)
- )
+  p = suppressMessages(survplot(msm_fit, km = TRUE, grid = 5))
 
-  expect_named(out, c("p", "fitted", "km"))
-  expect_s3_class(out$p, "ggplot")
-  expect_s3_class(out$fitted, "data.table")
-  expect_s3_class(out$km, "data.table")
+  expect_s3_class(p, "ggplot")
+  expect_s3_class(p$fitted, "data.table")
+  expect_s3_class(p$km, "data.table")
 })
 
 test_that("survplot can return without printing", {
   msm_fit = test_msm_fit()
   utils::capture.output(
-    out <- survplot(msm_fit, km = TRUE, out = "all", grid = 5,
-                     print_plot = FALSE)
+    p <- survplot(msm_fit, km = TRUE, grid = 5, print_plot = FALSE)
  )
 
-  expect_named(out, c("p", "fitted", "km"))
-  expect_s3_class(out$p, "ggplot")
-  expect_s3_class(out$fitted, "data.table")
-  expect_s3_class(out$km, "data.table")
+  expect_s3_class(p, "ggplot")
+  expect_s3_class(p$fitted, "data.table")
+  expect_s3_class(p$km, "data.table")
 })
 
 test_that("prevplot returns a ggplot object", {
@@ -87,37 +82,36 @@ test_that("plot verbosity controls messages", {
 
 test_that("survplot with ci = 'normal' returns survival curves with bounds", {
   msm_fit = test_msm_fit()
-  out = suppressMessages(
+  p = suppressMessages(
     survplot(msm_fit, km = TRUE, ci = "normal", ci_km = "log",
-             out = "all", grid = 5, B = 2L, print_plot = FALSE)
+             grid = 5, B = 2L, print_plot = FALSE)
  )
 
-  expect_named(out, c("p", "fitted", "km"))
-  expect_s3_class(out$p, "ggplot")
-  expect_true(all(c("lwr", "upr") %in% names(out$fitted)))
-  expect_true(all(c("lwr", "upr") %in% names(out$km)))
+  expect_s3_class(p, "ggplot")
+  expect_true(all(c("lwr", "upr") %in% names(p$fitted)))
+  expect_true(all(c("lwr", "upr") %in% names(p$km)))
 })
 
 test_that("survplot honours exacttimes = FALSE", {
   msm_fit = test_msm_fit()
-  out = suppressMessages(
+  p = suppressMessages(
     survplot(msm_fit, km = TRUE, exacttimes = FALSE, ci_km = "log",
-             out = "all", grid = 5, print_plot = FALSE)
+             grid = 5, print_plot = FALSE)
  )
 
-  expect_s3_class(out$p, "ggplot")
-  expect_false("time_exact" %in% names(out$km))
+  expect_s3_class(p, "ggplot")
+  expect_false("time_exact" %in% names(p$km))
 })
 
 test_that("survplot honours interp = 'midpoint'", {
   msm_fit = test_msm_fit()
-  out = suppressMessages(
-    survplot(msm_fit, km = TRUE, interp = "midpoint", out = "all",
+  p = suppressMessages(
+    survplot(msm_fit, km = TRUE, interp = "midpoint",
              grid = 5, print_plot = FALSE)
  )
 
-  expect_s3_class(out$p, "ggplot")
-  expect_s3_class(out$km, "data.table")
+  expect_s3_class(p, "ggplot")
+  expect_s3_class(p$km, "data.table")
 })
 
 test_that("survplot supports custom range and times", {
@@ -141,17 +135,27 @@ test_that("survplot supports custom range and times", {
   expect_s3_class(out_times_inexact, "ggplot")
 })
 
-test_that("survplot out = 'fitted' / 'km' return shaped lists", {
+test_that("survplot attaches $fitted always and $km only when km = TRUE", {
   msm_fit = test_msm_fit()
-  out_fitted = suppressMessages(
-    survplot(msm_fit, out = "fitted", grid = 5, print_plot = FALSE)
+  p_no_km = suppressMessages(
+    survplot(msm_fit, grid = 5, print_plot = FALSE)
  )
-  out_km = suppressMessages(
-    survplot(msm_fit, km = TRUE, out = "km", grid = 5, print_plot = FALSE)
+  p_km = suppressMessages(
+    survplot(msm_fit, km = TRUE, grid = 5, print_plot = FALSE)
  )
 
-  expect_named(out_fitted, c("p", "fitted"))
-  expect_named(out_km, c("p", "km"))
+  expect_s3_class(p_no_km$fitted, "data.table")
+  expect_null(p_no_km$km)
+  expect_s3_class(p_km$fitted, "data.table")
+  expect_s3_class(p_km$km, "data.table")
+})
+
+test_that("survplot's $fitted survives print()", {
+  msm_fit = test_msm_fit()
+  p = suppressMessages(survplot(msm_fit, km = TRUE, grid = 5, print_plot = FALSE))
+  out = utils::capture.output(print(p))
+  expect_s3_class(p$fitted, "data.table")
+  expect_s3_class(p$km, "data.table")
 })
 
 test_that("survplot errors on invalid inputs", {
@@ -165,13 +169,18 @@ test_that("survplot errors on invalid inputs", {
     survplot(msm_fit, to = 1, print_plot = FALSE),
     "to must be an absorbing state"
  )
+})
+
+test_that("survplot rejects the removed `out` argument with a helpful error", {
+  msm_fit = test_msm_fit()
+
   expect_error(
-    survplot(msm_fit, km = FALSE, out = "km", grid = 5, print_plot = FALSE),
-    "km = TRUE"
+    survplot(msm_fit, out = "all", grid = 5, print_plot = FALSE),
+    "removed in msmtools 2\\.2\\.0"
  )
   expect_error(
-    survplot(msm_fit, km = FALSE, out = "all", grid = 5, print_plot = FALSE),
-    "km = TRUE"
+    survplot(msm_fit, out = "fitted", grid = 5, print_plot = FALSE),
+    "p\\$fitted"
  )
 })
 

--- a/vignettes/msmtools.Rmd
+++ b/vignettes/msmtools.Rmd
@@ -135,15 +135,16 @@ msm_model <- msm(
 ```
 
 ```{r survival-plot, fig.width = 7, fig.height = 4}
-surv_out <- survplot(msm_model, km = TRUE, out = "all", grid = 10)
-surv_out$p
+surv_p <- survplot(msm_model, km = TRUE, grid = 10)
+surv_p
 ```
 
-The fitted and Kaplan-Meier data used by the plot are also returned.
+The fitted and Kaplan-Meier data tables are attached to the plot as
+named fields, accessible with the standard `$` operator:
 
 ```{r survival-data}
-surv_out$fitted[1:6]
-surv_out$km[1:6]
+surv_p$fitted[1:6]
+surv_p$km[1:6]
 ```
 
 # Prevalence Plot
@@ -163,7 +164,15 @@ prev <- prevalence.msm(
   )
 )
 
-prevplot(msm_model, prev, ci = TRUE, M = FALSE)
+prev_p <- prevplot(msm_model, prev, ci = TRUE, M = FALSE)
+prev_p
+```
+
+The long-format prevalence data used to build the plot is attached as
+`$prevalence`:
+
+```{r prevalence-data}
+prev_p$prevalence[1:6]
 ```
 
 # Notes


### PR DESCRIPTION
## Summary

Closes [#4](https://github.com/contefranz/msmtools/issues/4). Brings `survplot()` and `prevplot()` to a single, predictable return contract: **both always return a plot**, with the underlying data tables decorating that plot as named `$` fields.

```r
p <- survplot(model, km = TRUE)
p           # prints the plot
p$fitted    # data.table — survival probabilities
p$km        # data.table — Kaplan-Meier curve

q <- prevplot(model, prev_obj)
q              # prints the plot
q$prevalence   # data.table — observed/expected/CI in long form
```

The headline change is the **return type collapsing from a wrapper list to a ggplot**: `ggsave(p)`, `p + theme_bw()`, `p1 + p2` (patchwork), and autoprint now work directly on the plot — no more `out\$p` unwrap step anywhere in the ggplot ecosystem.

## Breaking change

`survplot()` no longer accepts the `out = c("none", "fitted", "km", "all")` argument. Calls that previously did

```r
out <- survplot(model, km = TRUE, out = "all")
out\$fitted
```

should drop the \`out\` argument and access the data tables directly on the returned plot:

```r
p <- survplot(model, km = TRUE)
p\$fitted
```

For one release the function traps any legacy `out = ...` call and raises a clear migration error pointing at the new pattern. **The trampoline itself will be removed in v2.3.0.**

## Version bump rationale

`v2.2.0`, not `3.0.0`. msmtools has a narrow plotting API and a small user base; the prominent NEWS entry and the migration trampoline keep the upgrade path smooth without inflating the major version. `cran-comments.md` documents the choice explicitly.

## Test plan

- [x] `devtools::test()` — 189 / 189 pass.
- [x] `covr::package_coverage()` — 98.17%.
- [x] `R CMD check --as-cran` — same clean status as 2.1.4 (only environmental LaTeX/HTML Tidy issues; CRAN-incoming "archived" NOTE for new submission).
- [x] `_R_CHECK_DEPENDS_ONLY_=true R CMD check --as-cran --no-manual --no-build-vignettes` — clean; patchwork test still skips correctly.

Closes #4.