### PR TITLE
Expand cran-comments.md with post-archival history

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,50 +1,116 @@
 # msmtools 2.2.0
 
-### Release summary
+### Resubmission after archival
 
-This release closes a long-standing API asymmetry between `survplot()`
-and `prevplot()` (GitHub issue #4). The `out` argument has been removed
-from `survplot()`; the function now always returns a `gg/ggplot` object,
-with the fitted survival and Kaplan-Meier data tables exposed as named
-fields on the returned plot (`p$fitted`, `p$km`). `prevplot()` gains
-the equivalent `p$prevalence` field. Both functions now compose
-directly with the ggplot ecosystem — `ggsave()`, `+`, and `patchwork`
-work on the returned plot without an unwrap step.
+This is the first CRAN submission of **msmtools** since the package was
+archived on **2024-09-27**. The archival was caused by uncorrected
+compatibility issues with newer **data.table** releases: `substitute()`
+calls on the left-hand side of `:=` assignments (a non-standard
+evaluation pattern that **data.table** deprecated), plus
+`eval(substitute(data$var))` constructs throughout `augment()` and
+`polish()`. Those constructs produced errors against current
+**data.table** versions on CRAN.
 
-This is an intentional breaking change. Calls that previously used
-`out = "all"` (or any other `out` value) now raise a clear migration
-error pointing to the `$fitted` / `$km` access pattern. The trampoline
-that catches the legacy argument will itself be removed in v2.3.0.
+The non-standard evaluation cleanup landed in **2.0.2** (column
+assignment now uses the recommended `(var) :=` idiom and per-column
+access goes through `data[[var]]`). That fix was bundled into the
+**2.0.3** resubmission, but the resubmission was not completed
+end-to-end because rhub checks could not run locally at the time and
+win-builder feedback was still pending. Subsequent maintenance work has
+since continued on GitHub without another submission attempt.
 
-The version bump is to 2.2.0 rather than 3.0.0. msmtools has a narrow
-plotting API and a small user base; documenting the breaking change
-prominently in NEWS and providing the migration trampoline are
-sufficient to keep the upgrade path smooth without inflating the major
-version.
+`R CMD check --as-cran` will emit the `New submission / Package was
+archived on CRAN` NOTE; that NOTE is expected and acknowledged here.
 
-### Package development
+### Maintenance arc since 2.0.3
 
-* macOS Tahoe 26.5 with R 4.5.1
+Between the never-completed 2.0.3 resubmission and this 2.2.0
+submission the package has gone through nine point releases. The main
+milestones are:
+
+* **2.0.4 – 2.0.10**: raised the supported baseline to R 4.1 and
+  current CRAN releases of the runtime imports; split `augment()` into
+  private helpers for validation, event preparation, pattern matching,
+  status construction, time-column creation, and expanded-status
+  handling; `augment()` and `polish()` now always return `data.table`
+  objects.
+* **2.1.0 – 2.1.2**: replaced the `verbose` argument (which manipulated
+  `sink()` and warning options) with a `verbosity` argument routed
+  through **cli**. Levels are `"quiet"`, `"summary"`, and `"progress"`,
+  with the latter producing optional progress bars through
+  `cli::cli_progress_bar()`. The same refactor was applied to
+  `polish()` and to the plotting functions.
+* **2.1.3**: dependency tightening. `scales` was removed entirely (its
+  single percent-formatter use replaced by an inline labeller).
+  `patchwork` was moved from `Imports` to `Suggests`, since it is only
+  required by `prevplot(M = TRUE)`; the call site now guards with
+  `requireNamespace()` and raises an informative error if the package
+  is not installed. Documentation framing was generalised away from
+  hospital-only language.
+* **2.1.4**: **bug fix with statistical implications.**
+  [Issue #7](https://github.com/contefranz/msmtools/issues/7) reported
+  that `augment()` was collapsing the post-discharge at-risk window for
+  alive subjects — the final transition row used the last `t_end`
+  instead of `t_cens`, so the at-risk window for any subject who
+  survived to the censoring date was truncated to zero duration. Any
+  `msm` model fitted on the augmented output therefore biased
+  transition-rate estimates downward. The fix routes the trailing OUT
+  row through `t_cens` for alive subjects only; the behaviour for
+  subjects who died is unchanged. This is a deliberate behavioural
+  change. Models refit on output produced by `augment()` from
+  msmtools 2.1.4 and later will give different (and more correct)
+  parameter estimates than models fitted on output from earlier
+  versions. The change is documented prominently in `NEWS.md` and
+  the internal regression fixture was regenerated against the
+  corrected output.
+
+### Current release (2.2.0)
+
+`survplot()` and `prevplot()` are now brought to a single return
+contract. The `out = c("none", "fitted", "km", "all")` argument on
+`survplot()` has been removed; the function always returns a
+`gg/ggplot` object, with the fitted survival and Kaplan-Meier data
+tables exposed as named fields on that plot (`p$fitted`, `p$km`).
+`prevplot()` exposes the underlying long-format prevalence data via
+`p$prevalence` for parity. Closes
+[issue #4](https://github.com/contefranz/msmtools/issues/4).
+
+This is an intentional breaking change. Calls passing `out = ...` raise
+a clear migration error pointing to the new pattern via a one-release
+trampoline (the `...` capture inside `survplot()`), which will itself
+be removed in v2.3.0. The version bump is to 2.2.0 rather than 3.0.0:
+msmtools has a narrow plotting API and a small user base, and the
+prominent NEWS entry plus the migration trampoline are sufficient to
+keep the upgrade path smooth without inflating the major version.
+
+### Package development environment
+
+* macOS Tahoe 26.5 with R 4.5.1.
 
 ### R CMD build
 
-* local macOS build with `R CMD build`
-* vignette built locally with pandoc discovered through Quarto
+* Local macOS build with `R CMD build .`; pandoc is discovered through
+  Quarto for vignette rendering.
 * win-builder R-release and R-devel submissions pending at the time of
-  writing
-* GitHub Actions matrix (macOS R-release, Windows R-release, Ubuntu
-  R-devel, R-release, R-oldrel-1) green on the release branch
+  writing.
+* GitHub Actions matrix — macOS R-release, Windows R-release, Ubuntu
+  R-devel, Ubuntu R-release, Ubuntu R-oldrel-1 — green on the release
+  branch.
 
 ### R CMD check results
 
-* Target: 0 errors, 0 warnings, 0 notes on local `R CMD check --as-cran`.
+* Target: 0 errors, 0 warnings, 0 notes on `R CMD check --as-cran`.
 * The `--no-suggests` path is verified locally via
   `_R_CHECK_DEPENDS_ONLY_=true R CMD check --as-cran`: the conditional
-  `patchwork` test is skipped through `testthat::skip_if_not_installed`
-  and `prevplot(M = FALSE)` continues to work without `patchwork`
+  `patchwork` test in `tests/testthat/test-plots.R` skips correctly
+  through `testthat::skip_if_not_installed("patchwork")`, and
+  `prevplot(M = FALSE)` continues to work without `patchwork`
   installed.
-* The only expected NOTE in restricted environments is the offline
-  URL/DOI check. These resolve correctly when the check has network
-  access.
+* The expected NOTE in restricted environments is the offline URL/DOI
+  check (JSS DOI on `prevplot()`'s `@references` block, plus the
+  CRAN-incoming feasibility check). These resolve correctly when the
+  check has network access. The `New submission / Package was archived
+  on CRAN` NOTE is also expected and is acknowledged in the
+  resubmission framing above.
 
 ***


### PR DESCRIPTION
## Summary

\`cran-comments.md\` currently reads like a routine update note for v2.2.0, but v2.2.0 is actually the first version going to CRAN since msmtools was archived on **2024-09-27**. CRAN reviewers seeing the \`New submission / Package was archived on CRAN\` incoming NOTE deserve the full picture, not just the changes in this one release.

Rewrites cran-comments.md into three sections:

1. **Resubmission framing** — the 2024 archival cause (data.table NSE deprecations: \`substitute()\` on LHS of \`:=\` and \`eval(substitute(data\$var))\`), the 2.0.2 NSE remediation that resolved it, and the never-completed 2.0.3 resubmission attempt.

2. **Maintenance arc 2.0.3 → 2.2.0** — compact paragraph naming the 2.0.4–2.0.10 modernization, the 2.1.0–2.1.2 cli-based verbosity refactor, the 2.1.3 dependency tightening (\`scales\` removed, \`patchwork\` demoted to Suggests), and the 2.1.4 statistical bug fix for issue #7 — with an explicit callout that estimation results change for downstream users.

3. **Current release (2.2.0)** — survplot/prevplot API symmetry closing #4, the one-release migration trampoline for legacy \`out = ...\` calls, and the rationale for the minor (not major) version bump.

Tone is factual and matter-of-fact, no apology or flourish.

## Files

- \`cran-comments.md\` only.

\`cran-comments.md\` is already in \`.Rbuildignore\`, so this is documentation-only: no code, no tests, no package payload change.

## Test plan

- [x] Reads coherently from top to bottom for a reviewer with no prior context.
- [x] \`git diff main -- cran-comments.md\` is the only file diff.
- [x] No package payload affected — \`R CMD check\` is unchanged.